### PR TITLE
fix: reduce vertical padding in worker cards on mobile

### DIFF
--- a/web/src/components/WorkersPanel.module.css
+++ b/web/src/components/WorkersPanel.module.css
@@ -128,4 +128,21 @@
   .mobileOpen {
     display: flex;
   }
+
+  .card {
+    margin: 0 var(--mobile-gutter) 8px;
+    padding: 10px 14px;
+  }
+
+  .top {
+    margin-bottom: 4px;
+  }
+
+  .desc {
+    margin-bottom: 5px;
+  }
+
+  .attemptDetail {
+    margin-top: 4px;
+  }
 }


### PR DESCRIPTION
## Summary
- Tightens vertical spacing in worker cards inside the `@media (max-width: 768px)` block in `WorkersPanel.module.css`
- Reduces card bottom margin (10px → 8px) and padding (15px 15px 14px → 10px 14px)
- Adds mobile overrides for `.top`, `.desc`, and `.attemptDetail` spacing

## Test plan
- [ ] TypeScript check passes (`npx tsc --noEmit`)
- [ ] All 154 frontend tests pass (`npx vitest run`)
- [ ] Worker list is more compact on mobile (≤768px screens)
- [ ] No regressions on desktop layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)