### PR TITLE
feat: QuickDispatch modal with Cmd+Enter shortcut hint

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback, useMemo, useRef } from "react";
 import { TopBar } from "./components/TopBar";
 import { CommandPalette } from "./components/CommandPalette";
+import QuickDispatch from "./components/QuickDispatch/QuickDispatch";
 import { BotNav } from "./components/BotNav";
 import { ChatPanel } from "./components/ChatPanel";
 import { ReposPanel } from "./components/ReposPanel";
@@ -80,6 +81,7 @@ export default function App() {
   const [loadingStatus, setLoadingStatus] = useState<string | undefined>();
   const [unread, setUnread] = useState<Record<string, number>>({});
   const [paletteOpen, setPaletteOpen] = useState(false);
+  const [quickDispatchOpen, setQuickDispatchOpen] = useState(false);
   const [otherWorkspaceBots, setOtherWorkspaceBots] = useState<CrossWorkspaceBot[]>([]);
   const [docsOpen, setDocsOpen] = useState(false);
   const [simulatorOpen, setSimulatorOpen] = useState(false);
@@ -447,6 +449,23 @@ export default function App() {
     return () => window.removeEventListener("keydown", handleGlobalKeyDown);
   }, []);
 
+  // N key: open quick dispatch (when not focused in an input)
+  useEffect(() => {
+    function handleNKey(e: KeyboardEvent) {
+      if (
+        e.key === "n" &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !(e.target instanceof HTMLInputElement) &&
+        !(e.target instanceof HTMLTextAreaElement)
+      ) {
+        setQuickDispatchOpen(true);
+      }
+    }
+    window.addEventListener("keydown", handleNKey);
+    return () => window.removeEventListener("keydown", handleNKey);
+  }, []);
+
   const handleSelectWorkspace = useCallback((ws: string, wsRemote?: string) => {
     setWorkspace(ws);
     setRemote(wsRemote);
@@ -645,6 +664,16 @@ export default function App() {
         />
       </div>
       <SimulatorPanel open={simulatorOpen} onClose={() => setSimulatorOpen(false)} />
+      {quickDispatchOpen && (
+        <QuickDispatch
+          workspace={workspace}
+          onClose={() => setQuickDispatchOpen(false)}
+          onDispatched={() => {
+            setQuickDispatchOpen(false);
+            if (workspace) api.getWorkers(workspace, remote).then(setWorkers);
+          }}
+        />
+      )}
       <CommandPalette
         open={paletteOpen}
         onOpenChange={setPaletteOpen}

--- a/web/src/__mocks__/api.ts
+++ b/web/src/__mocks__/api.ts
@@ -49,3 +49,5 @@ export const cancelFollowup = vi.fn().mockResolvedValue({ ok: true });
 export const getResearchTasks = vi.fn().mockResolvedValue([]);
 export const startResearch = vi.fn().mockResolvedValue({ id: "research-1", topic: "test", status: "running" });
 export const connectWebSocket = vi.fn().mockReturnValue({ close: vi.fn() });
+export const createWorkerV2 = vi.fn().mockResolvedValue({ id: "worker-1" });
+export const getWorkerDiff = vi.fn().mockResolvedValue(null);

--- a/web/src/__tests__/QuickDispatch.test.tsx
+++ b/web/src/__tests__/QuickDispatch.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import QuickDispatch from "../components/QuickDispatch/QuickDispatch";
+import * as api from "../api";
+
+vi.mock("../api");
+
+const mockRepos = [
+  { name: "apiari", path: "/repos/apiari", has_swarm: true, is_clean: true, branch: "main", workers: [] },
+  { name: "mgm", path: "/repos/mgm", has_swarm: false, is_clean: true, branch: "main", workers: [] },
+];
+
+const defaultProps = {
+  workspace: "apiari",
+  onClose: vi.fn(),
+  onDispatched: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.mocked(api.getRepos).mockResolvedValue(mockRepos);
+  vi.mocked(api.createWorkerV2).mockResolvedValue({ id: "worker-new" });
+  defaultProps.onClose.mockClear();
+  defaultProps.onDispatched.mockClear();
+});
+
+describe("QuickDispatch", () => {
+  it("renders the intent textarea", () => {
+    render(<QuickDispatch {...defaultProps} />);
+    expect(screen.getByTestId("intent-textarea")).toBeInTheDocument();
+  });
+
+  it("renders repo pills after fetch", async () => {
+    render(<QuickDispatch {...defaultProps} />);
+    expect(await screen.findByTestId("repo-pill-apiari")).toBeInTheDocument();
+    expect(screen.getByTestId("repo-pill-mgm")).toBeInTheDocument();
+  });
+
+  it("dispatch button is disabled when intent is empty", async () => {
+    render(<QuickDispatch {...defaultProps} />);
+    await screen.findByTestId("repo-pill-apiari");
+    expect(screen.getByTestId("dispatch-btn")).toBeDisabled();
+  });
+
+  it("dispatch button is disabled when no repo is selected", async () => {
+    vi.mocked(api.getRepos).mockResolvedValue([]);
+    render(<QuickDispatch {...defaultProps} />);
+    const textarea = screen.getByTestId("intent-textarea");
+    fireEvent.change(textarea, { target: { value: "Fix the auth flow" } });
+    await waitFor(() => {
+      expect(screen.getByTestId("dispatch-btn")).toBeDisabled();
+    });
+  });
+
+  it("dispatch button is enabled when intent and repo are both filled", async () => {
+    render(<QuickDispatch {...defaultProps} />);
+    await screen.findByTestId("repo-pill-apiari");
+    const textarea = screen.getByTestId("intent-textarea");
+    fireEvent.change(textarea, { target: { value: "Fix the auth flow" } });
+    expect(screen.getByTestId("dispatch-btn")).not.toBeDisabled();
+  });
+
+  it("Escape key calls onClose", () => {
+    render(<QuickDispatch {...defaultProps} />);
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it("clicking Cancel calls onClose", () => {
+    render(<QuickDispatch {...defaultProps} />);
+    fireEvent.click(screen.getByTestId("cancel-btn"));
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it("clicking the overlay backdrop calls onClose", () => {
+    render(<QuickDispatch {...defaultProps} />);
+    const overlay = screen.getByTestId("quick-dispatch-overlay");
+    fireEvent.mouseDown(overlay, { target: overlay });
+    expect(defaultProps.onClose).toHaveBeenCalled();
+  });
+
+  it("successful dispatch calls onDispatched with worker id", async () => {
+    render(<QuickDispatch {...defaultProps} />);
+    await screen.findByTestId("repo-pill-apiari");
+    const textarea = screen.getByTestId("intent-textarea");
+    fireEvent.change(textarea, { target: { value: "Add rate limiting" } });
+    fireEvent.click(screen.getByTestId("dispatch-btn"));
+    await waitFor(() => {
+      expect(defaultProps.onDispatched).toHaveBeenCalledWith("worker-new");
+    });
+  });
+
+  it("calls createWorkerV2 with correct arguments", async () => {
+    render(<QuickDispatch {...defaultProps} />);
+    await screen.findByTestId("repo-pill-apiari");
+    const textarea = screen.getByTestId("intent-textarea");
+    fireEvent.change(textarea, { target: { value: "Fix rate limit bug" } });
+    fireEvent.click(screen.getByTestId("dispatch-btn"));
+    await waitFor(() => {
+      expect(api.createWorkerV2).toHaveBeenCalledWith(
+        "apiari",
+        expect.objectContaining({
+          repo: "apiari",
+          brief: expect.objectContaining({
+            goal: "Fix rate limit bug",
+            repo: "apiari",
+            review_mode: "local_first",
+          }),
+        }),
+      );
+    });
+  });
+
+  it("shows error message when dispatch fails", async () => {
+    vi.mocked(api.createWorkerV2).mockRejectedValue(new Error("Network error"));
+    render(<QuickDispatch {...defaultProps} />);
+    await screen.findByTestId("repo-pill-apiari");
+    const textarea = screen.getByTestId("intent-textarea");
+    fireEvent.change(textarea, { target: { value: "Fix bug" } });
+    fireEvent.click(screen.getByTestId("dispatch-btn"));
+    expect(await screen.findByTestId("dispatch-error")).toHaveTextContent("Network error");
+    expect(defaultProps.onDispatched).not.toHaveBeenCalled();
+  });
+
+  it("selecting a different repo pill updates selection", async () => {
+    render(<QuickDispatch {...defaultProps} />);
+    await screen.findByTestId("repo-pill-apiari");
+    const mgmPill = screen.getByTestId("repo-pill-mgm");
+    fireEvent.click(mgmPill);
+    expect(mgmPill).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("repo-pill-apiari")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("review mode toggles between local_first and pr_first", async () => {
+    render(<QuickDispatch {...defaultProps} />);
+    const localBtn = screen.getByTestId("review-mode-local");
+    const prBtn = screen.getByTestId("review-mode-pr");
+    expect(localBtn).toHaveAttribute("aria-pressed", "true");
+    expect(prBtn).toHaveAttribute("aria-pressed", "false");
+    fireEvent.click(prBtn);
+    expect(prBtn).toHaveAttribute("aria-pressed", "true");
+    expect(localBtn).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("shows Cmd+Enter keyboard shortcut hint next to Dispatch button", () => {
+    render(<QuickDispatch {...defaultProps} />);
+    const hint = screen.getByTestId("shortcut-hint");
+    expect(hint).toBeInTheDocument();
+    expect(hint.textContent).toBe("⌘↵");
+  });
+
+  it("Cmd+Enter dispatches when intent and repo are filled", async () => {
+    render(<QuickDispatch {...defaultProps} />);
+    await screen.findByTestId("repo-pill-apiari");
+    const textarea = screen.getByTestId("intent-textarea");
+    fireEvent.change(textarea, { target: { value: "Fix the login bug" } });
+    fireEvent.keyDown(window, { key: "Enter", metaKey: true });
+    await waitFor(() => {
+      expect(defaultProps.onDispatched).toHaveBeenCalledWith("worker-new");
+    });
+  });
+
+  it("Cmd+Enter does nothing when intent is empty", async () => {
+    render(<QuickDispatch {...defaultProps} />);
+    await screen.findByTestId("repo-pill-apiari");
+    fireEvent.keyDown(window, { key: "Enter", metaKey: true });
+    await waitFor(() => {
+      expect(defaultProps.onDispatched).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -253,6 +253,30 @@ export async function getWorkerDiff(workspace: string, workerId: string, remote?
   return data.diff;
 }
 
+export async function createWorkerV2(
+  workspace: string,
+  data: {
+    brief: {
+      goal: string;
+      repo: string;
+      review_mode: string;
+      context: Record<string, unknown>;
+      constraints: unknown[];
+      scope: unknown[];
+      acceptance_criteria: unknown[];
+    };
+    repo: string;
+  },
+): Promise<{ id: string }> {
+  const res = await fetch(`${BASE}/workspaces/${workspace}/v2/workers`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) throw new Error(`create worker: ${res.status}`);
+  return res.json();
+}
+
 export async function sendMessage(
   workspace: string,
   bot: string,

--- a/web/src/components/QuickDispatch/QuickDispatch.module.css
+++ b/web/src/components/QuickDispatch/QuickDispatch.module.css
@@ -1,0 +1,189 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.7);
+  z-index: 300;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+.panel {
+  width: 540px;
+  max-width: calc(100vw - 32px);
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
+  padding: 24px;
+  overflow-y: auto;
+  max-height: calc(100vh - 64px);
+}
+
+.label {
+  display: block;
+  font-size: 12px;
+  color: var(--text-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.intentTextarea {
+  width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-strong);
+  font-family: var(--font);
+  font-size: 16px;
+  padding: 12px;
+  resize: none;
+  line-height: 1.5;
+  outline: none;
+  transition: border-color 120ms;
+}
+
+.intentTextarea::placeholder {
+  color: var(--text-faint);
+}
+
+.intentTextarea:focus {
+  border-color: var(--text-faint);
+}
+
+.repoSection {
+  margin-top: 20px;
+}
+
+.pills {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.pill {
+  height: 32px;
+  padding: 0 12px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 13px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  transition: border-color 100ms, background 100ms, color 100ms;
+}
+
+.pill:hover {
+  color: var(--text-strong);
+}
+
+.pillSelected {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: rgba(245, 197, 66, 0.1);
+}
+
+.pillSelected:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+  background: rgba(245, 197, 66, 0.15);
+}
+
+.reviewSection {
+  margin-top: 20px;
+}
+
+.footer {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  margin-top: 24px;
+  border-top: 1px solid var(--border);
+  padding-top: 16px;
+}
+
+.errorMsg {
+  width: 100%;
+  font-size: 12px;
+  color: var(--red);
+  margin-top: 8px;
+  text-align: right;
+}
+
+.cancelBtn {
+  height: 32px;
+  padding: 0 12px;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 14px;
+  cursor: pointer;
+  border-radius: var(--radius);
+  transition: color 100ms;
+}
+
+.cancelBtn:hover {
+  color: var(--text-strong);
+}
+
+.shortcutHint {
+  font-size: 12px;
+  color: var(--text-faint);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-family: var(--font);
+  letter-spacing: 0.02em;
+  user-select: none;
+}
+
+.dispatchBtn {
+  height: 32px;
+  padding: 0 16px;
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius);
+  color: #111;
+  font-family: var(--font);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: opacity 100ms;
+}
+
+.dispatchBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.dispatchBtn:not(:disabled):hover {
+  opacity: 0.9;
+}
+
+.spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(0, 0, 0, 0.3);
+  border-top-color: #111;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}

--- a/web/src/components/QuickDispatch/QuickDispatch.tsx
+++ b/web/src/components/QuickDispatch/QuickDispatch.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useRef, useState } from 'react'
+import { getRepos, createWorkerV2 } from '../../api'
+import type { Repo } from '../../types'
+import styles from './QuickDispatch.module.css'
+
+export interface QuickDispatchProps {
+  workspace: string
+  onClose: () => void
+  onDispatched: (workerId: string) => void
+}
+
+type ReviewMode = 'local_first' | 'pr_first'
+
+export default function QuickDispatch({ workspace, onClose, onDispatched }: QuickDispatchProps) {
+  const [intent, setIntent] = useState('')
+  const [repos, setRepos] = useState<Repo[]>([])
+  const [selectedRepo, setSelectedRepo] = useState<string | null>(null)
+  const [reviewMode, setReviewMode] = useState<ReviewMode>('local_first')
+  const [dispatching, setDispatching] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    getRepos(workspace)
+      .then((list) => {
+        setRepos(list)
+        if (list.length > 0 && selectedRepo === null) {
+          setSelectedRepo(list[0].name)
+        }
+      })
+      .catch(() => {})
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspace])
+
+  useEffect(() => {
+    textareaRef.current?.focus()
+  }, [])
+
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        onClose()
+      }
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        if (intent.trim() && selectedRepo && !dispatching) {
+          handleDispatch()
+        }
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [intent, selectedRepo, dispatching])
+
+  async function handleDispatch() {
+    if (!intent.trim() || !selectedRepo || dispatching) return
+    setDispatching(true)
+    setError(null)
+
+    try {
+      const worker = await createWorkerV2(workspace, {
+        brief: {
+          goal: intent.trim(),
+          repo: selectedRepo,
+          review_mode: reviewMode,
+          context: {},
+          constraints: [],
+          scope: [],
+          acceptance_criteria: [],
+        },
+        repo: selectedRepo,
+      })
+      onDispatched(worker.id)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Dispatch failed. Please try again.')
+      setDispatching(false)
+    }
+  }
+
+  const canDispatch = intent.trim().length > 0 && selectedRepo !== null && !dispatching
+
+  return (
+    <div
+      className={styles.overlay}
+      data-testid="quick-dispatch-overlay"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div
+        className={styles.panel}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Quick dispatch"
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        <label className={styles.label} htmlFor="quick-dispatch-intent">
+          What do you want to do?
+        </label>
+        <textarea
+          id="quick-dispatch-intent"
+          ref={textareaRef}
+          className={styles.intentTextarea}
+          rows={5}
+          placeholder="Fix the rate limiting on the API endpoint..."
+          value={intent}
+          onChange={(e) => setIntent(e.target.value)}
+          data-testid="intent-textarea"
+        />
+
+        <div className={styles.repoSection}>
+          <span className={styles.label}>Repo</span>
+          <div className={styles.pills} data-testid="repo-pills">
+            {repos.map((repo) => (
+              <button
+                key={repo.name}
+                type="button"
+                className={`${styles.pill} ${selectedRepo === repo.name ? styles.pillSelected : ''}`}
+                onClick={() => setSelectedRepo(repo.name)}
+                aria-pressed={selectedRepo === repo.name}
+                data-testid={`repo-pill-${repo.name}`}
+              >
+                {repo.name}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className={styles.reviewSection}>
+          <span className={styles.label}>Review mode</span>
+          <div className={styles.pills} data-testid="review-mode-pills">
+            <button
+              type="button"
+              className={`${styles.pill} ${reviewMode === 'local_first' ? styles.pillSelected : ''}`}
+              onClick={() => setReviewMode('local_first')}
+              aria-pressed={reviewMode === 'local_first'}
+              data-testid="review-mode-local"
+            >
+              Local first
+            </button>
+            <button
+              type="button"
+              className={`${styles.pill} ${reviewMode === 'pr_first' ? styles.pillSelected : ''}`}
+              onClick={() => setReviewMode('pr_first')}
+              aria-pressed={reviewMode === 'pr_first'}
+              data-testid="review-mode-pr"
+            >
+              PR first
+            </button>
+          </div>
+        </div>
+
+        {error && (
+          <p className={styles.errorMsg} role="alert" data-testid="dispatch-error">
+            {error}
+          </p>
+        )}
+
+        <div className={styles.footer}>
+          <button
+            type="button"
+            className={styles.cancelBtn}
+            onClick={onClose}
+            data-testid="cancel-btn"
+          >
+            Cancel
+          </button>
+          <kbd className={styles.shortcutHint} data-testid="shortcut-hint">⌘↵</kbd>
+          <button
+            type="button"
+            className={styles.dispatchBtn}
+            disabled={!canDispatch}
+            onClick={handleDispatch}
+            data-testid="dispatch-btn"
+          >
+            {dispatching && <span className={styles.spinner} aria-hidden="true" />}
+            Dispatch
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds a `QuickDispatch` overlay modal (triggered by `N` key when not in an input)
- Modal lets users type an intent, pick a repo, set review mode, and dispatch a worker in one shot
- Shows a `⌘↵` keyboard hint next to the Dispatch button so the shortcut is discoverable
- `Cmd+Enter` / `Ctrl+Enter` fires the dispatch; `Escape` closes the modal
- `createWorkerV2` API function added (POST `/api/workspaces/{ws}/v2/workers`)
- 16 new tests covering render, repo/review selection, dispatch, error state, Escape, shortcut hint visibility, and Cmd+Enter behavior

## Test plan

- [ ] `cd web && npx vitest run` — all 186 tests pass
- [ ] `npx tsc --noEmit` — no type errors
- [ ] `cargo clippy -- -D warnings` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)