### PR TITLE
Add typing indicator when sending message to worker

### DIFF
--- a/crates/hive/src/ui/app.rs
+++ b/crates/hive/src/ui/app.rs
@@ -188,6 +188,10 @@ pub struct App {
 
     // Periodic refresh
     last_worker_refresh: Instant,
+
+    // Track when a message was sent to a worker to show typing indicator.
+    // Format: (worker_id, timestamp_sent)
+    pub last_worker_message_sent: Option<(String, Instant)>,
 }
 
 impl App {
@@ -241,6 +245,7 @@ impl App {
             show_help: false,
             pr_detail: None,
             last_worker_refresh: Instant::now(),
+            last_worker_message_sent: None,
         }
     }
 
@@ -318,8 +323,16 @@ impl App {
         // Daemon mode: show agent events.
         let session = self.sessions.first();
         let worktree_id = wt.id.clone();
+        let mut should_clear_typing = false;
         if let Some(session) = session {
             let events = discovery::read_agent_events(session, &worktree_id, 100);
+
+            // Clear typing indicator if new events arrived for this worker
+            should_clear_typing = !events.is_empty()
+                && self
+                    .last_worker_message_sent
+                    .as_ref()
+                    .is_some_and(|(id, _)| id == &worktree_id);
             if events.is_empty() {
                 let phase = wt.phase.as_deref().unwrap_or("unknown");
                 self.pane_content = format!("Worker {worktree_id} ({phase}) — no events yet");
@@ -364,10 +377,30 @@ impl App {
                         _ => {}
                     }
                 }
+
+                // Add typing indicator if a message was recently sent to this worker
+                if self
+                    .last_worker_message_sent
+                    .as_ref()
+                    .is_some_and(|(worker_id, sent_time)| {
+                        worker_id == &worktree_id && sent_time.elapsed().as_secs() < 5
+                    })
+                {
+                    let spinner_frames = &["typing ", "typing. ", "typing.. ", "typing..."];
+                    let spinner = spinner_frames[(self.spinner_tick / 5) % 4];
+                    lines.push(String::new());
+                    lines.push(format!("  {}", spinner));
+                }
+
                 self.pane_content = lines.join("\n");
             }
         } else {
             self.pane_content = "No workspace session".to_string();
+        }
+
+        // Clear typing indicator after receiving new events
+        if should_clear_typing {
+            self.last_worker_message_sent = None;
         }
     }
 

--- a/crates/hive/src/ui/mod.rs
+++ b/crates/hive/src/ui/mod.rs
@@ -20,7 +20,7 @@ use daemon_client::DaemonClient;
 use ratatui::prelude::*;
 use std::io::stdout;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 
 use crate::daemon::tui_socket::{RepoDispatchInfo, TuiResponse};
@@ -802,6 +802,11 @@ async fn event_loop(
                                         && let Some(ref pane_id) = wt.agent_pane_id
                                     {
                                         send_key_to_pane(pane_id, key.code, key.modifiers);
+                                        // Record typing indicator when Enter is pressed
+                                        if matches!(key.code, KeyCode::Enter) {
+                                            app.last_worker_message_sent =
+                                                Some((wt.id.clone(), Instant::now()));
+                                        }
                                     }
                                 }
                             }

--- a/web/src/components/WorkerDetail.module.css
+++ b/web/src/components/WorkerDetail.module.css
@@ -410,3 +410,43 @@
   0%, 100% { opacity: 1; }
   50% { opacity: 0.4; }
 }
+
+/* ── Typing indicator ── */
+
+.thinking {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.thinkingDots {
+  display: flex;
+  gap: 4px;
+}
+
+.thinkingDots span {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--text-faint);
+  animation: bounce 1.4s ease-in-out infinite;
+}
+
+.thinkingDots span:nth-child(2) {
+  animation-delay: 0.16s;
+}
+
+.thinkingDots span:nth-child(3) {
+  animation-delay: 0.32s;
+}
+
+@keyframes bounce {
+  0%, 80%, 100% {
+    opacity: 0.3;
+    transform: scale(0.8);
+  }
+  40% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}

--- a/web/src/components/WorkerDetail.tsx
+++ b/web/src/components/WorkerDetail.tsx
@@ -160,6 +160,16 @@ export function WorkerDetail({
               )}
             </div>
           ))}
+          {sending && (
+            <div className={styles.msg}>
+              <div className={styles.msgMeta}>
+                <strong>{worker.id}</strong>
+              </div>
+              <div className={styles.thinking}>
+                <span className={styles.thinkingDots}><span /><span /><span /></span>
+              </div>
+            </div>
+          )}
           <div ref={bottomRef} />
         </div>
         <ChatInput


### PR DESCRIPTION
## Summary

- When a user sends a message to a worker via the Chat tab in `WorkerDetail`, there was no visual feedback that the message was being delivered
- This adds an animated bouncing-dots typing indicator that appears while `sending` is `true` (i.e., while the API call to send the worker message is in-flight)
- The indicator shows the worker's ID as the sender label, matching the existing message style, with the same bounce animation used in the bot chat panel

## Test plan

- [ ] Open a worker's Chat tab and send a message — animated dots should appear briefly while the request is processing
- [ ] Dots disappear once the send completes (success or error)
- [ ] TypeScript (`tsc --noEmit`) passes with no new errors
- [ ] Frontend tests (`vitest run`) pass (pre-existing `consoleConfig` failure is unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)