### PR TITLE
Add safe area inset padding to mobile bottom tab bar

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-content" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, interactive-widget=resizes-content, viewport-fit=cover" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="theme-color" content="#111111" />

--- a/web/src/components/BottomTabBar/BottomTabBar.module.css
+++ b/web/src/components/BottomTabBar/BottomTabBar.module.css
@@ -5,7 +5,7 @@
   display: flex;
   flex-direction: row;
   align-items: stretch;
-  padding-bottom: env(safe-area-inset-bottom);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
   min-height: var(--bottom-bar-height);
 }
 

--- a/web/src/components/BottomTabBar/BottomTabBar.module.css
+++ b/web/src/components/BottomTabBar/BottomTabBar.module.css
@@ -1,11 +1,12 @@
 .bar {
   width: 100%;
-  height: var(--bottom-bar-height);
   background: var(--bg-card);
   border-top: 1px solid var(--border);
   display: flex;
   flex-direction: row;
   align-items: stretch;
+  padding-bottom: env(safe-area-inset-bottom);
+  min-height: var(--bottom-bar-height);
 }
 
 .tab {
@@ -20,6 +21,7 @@
   color: var(--text-faint);
   cursor: pointer;
   padding: 0;
+  height: var(--bottom-bar-height);
   font-family: var(--font);
   transition: color 100ms;
 }

--- a/web/src/components/Layout/Layout.module.css
+++ b/web/src/components/Layout/Layout.module.css
@@ -107,6 +107,6 @@
   }
 
   .main {
-    padding-bottom: calc(var(--bottom-bar-height) + env(safe-area-inset-bottom));
+    padding-bottom: calc(var(--bottom-bar-height) + env(safe-area-inset-bottom, 0px));
   }
 }

--- a/web/src/components/Layout/Layout.module.css
+++ b/web/src/components/Layout/Layout.module.css
@@ -107,6 +107,6 @@
   }
 
   .main {
-    padding-bottom: var(--bottom-bar-height);
+    padding-bottom: calc(var(--bottom-bar-height) + env(safe-area-inset-bottom));
   }
 }


### PR DESCRIPTION
## Summary
- Adds `viewport-fit=cover` to the viewport meta tag so `env(safe-area-inset-bottom)` is available
- `BottomTabBar` now uses `padding-bottom: env(safe-area-inset-bottom)` so the bar extends into the iOS home indicator safe zone
- Tab buttons are given explicit `height: var(--bottom-bar-height)` so only the tap targets fill the visible bar area
- `Layout.main` padding-bottom on mobile is updated to `calc(var(--bottom-bar-height) + env(safe-area-inset-bottom))` so content is not obscured by the bar

## Test plan
- [ ] Build and open on an iPhone (or Safari with responsive mode set to a device with a home indicator)
- [ ] Verify the bottom tab bar extends to the very bottom of the screen, covering the home indicator area with the bar background
- [ ] Verify tab buttons are still centered within the visible 56px bar (not stretched into the safe zone)
- [ ] Verify main content is not hidden behind the tab bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)