### PR TITLE
Add LLM-generated display title for workers

### DIFF
--- a/crates/apiari/src/buzz/review.rs
+++ b/crates/apiari/src/buzz/review.rs
@@ -655,6 +655,7 @@ mod tests {
             state_entered_at: now.clone(),
             created_at: now.clone(),
             updated_at: now,
+            display_title: None,
             label: String::new(),
         }
     }

--- a/crates/apiari/src/buzz/swarm_reconciler.rs
+++ b/crates/apiari/src/buzz/swarm_reconciler.rs
@@ -600,6 +600,7 @@ mod tests {
             state_entered_at: now.clone(),
             created_at: now.clone(),
             updated_at: now,
+            display_title: None,
             label: "Queued".to_string(),
         }
     }

--- a/crates/apiari/src/buzz/worker.rs
+++ b/crates/apiari/src/buzz/worker.rs
@@ -204,8 +204,14 @@ pub fn ensure_schema(conn: &Connection) -> Result<()> {
         ",
     )
     .wrap_err("failed to create worker tables")?;
-    // Migration: add display_title to existing databases (safe to ignore if already present)
-    let _ = conn.execute_batch("ALTER TABLE workers ADD COLUMN display_title TEXT");
+    // Migration: add display_title column to existing databases.
+    // Ignore only "duplicate column" errors; surface anything else.
+    if let Err(e) = conn.execute_batch("ALTER TABLE workers ADD COLUMN display_title TEXT") {
+        let msg = e.to_string();
+        if !msg.contains("duplicate column") {
+            return Err(e).wrap_err("failed to migrate workers table (add display_title)");
+        }
+    }
     Ok(())
 }
 
@@ -808,5 +814,43 @@ mod tests {
 
         let w = store.get("acme", "w1").unwrap().unwrap();
         assert_eq!(w.state, WorkerState::Running);
+    }
+
+    #[test]
+    fn test_update_display_title_persisted() {
+        let store = WorkerStore::open_memory().unwrap();
+        store.upsert(&make_worker("w1", "acme")).unwrap();
+
+        store
+            .update_display_title("acme", "w1", "Add Rate Limiting to API")
+            .unwrap();
+
+        let w = store.get("acme", "w1").unwrap().unwrap();
+        assert_eq!(w.display_title.as_deref(), Some("Add Rate Limiting to API"));
+
+        let listed = store.list("acme").unwrap();
+        assert_eq!(
+            listed[0].display_title.as_deref(),
+            Some("Add Rate Limiting to API")
+        );
+    }
+
+    #[test]
+    fn test_upsert_does_not_clobber_display_title() {
+        let store = WorkerStore::open_memory().unwrap();
+        store.upsert(&make_worker("w1", "acme")).unwrap();
+        store
+            .update_display_title("acme", "w1", "Short Title")
+            .unwrap();
+
+        // Upsert with display_title: None should preserve the existing title
+        let mut w = make_worker("w1", "acme");
+        w.state = WorkerState::Running;
+        w.display_title = None;
+        store.upsert(&w).unwrap();
+
+        let fetched = store.get("acme", "w1").unwrap().unwrap();
+        assert_eq!(fetched.display_title.as_deref(), Some("Short Title"));
+        assert_eq!(fetched.state, WorkerState::Running);
     }
 }

--- a/crates/apiari/src/buzz/worker.rs
+++ b/crates/apiari/src/buzz/worker.rs
@@ -87,6 +87,8 @@ pub struct Worker {
     pub state_entered_at: String,
     pub created_at: String,
     pub updated_at: String,
+    /// Short LLM-generated title for display (stored in DB, filled in by row_to_worker).
+    pub display_title: Option<String>,
     /// Derived display label — computed, never stored in DB.
     #[serde(skip_deserializing)]
     pub label: String,
@@ -184,7 +186,8 @@ pub fn ensure_schema(conn: &Connection) -> Result<()> {
             last_output_at DATETIME,
             state_entered_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
             created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+            updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            display_title TEXT
         );
 
         CREATE TABLE IF NOT EXISTS worker_hooks (
@@ -201,6 +204,8 @@ pub fn ensure_schema(conn: &Connection) -> Result<()> {
         ",
     )
     .wrap_err("failed to create worker tables")?;
+    // Migration: add display_title to existing databases (safe to ignore if already present)
+    let _ = conn.execute_batch("ALTER TABLE workers ADD COLUMN display_title TEXT");
     Ok(())
 }
 
@@ -254,8 +259,8 @@ impl WorkerStore {
              (id, workspace, state, brief, repo, branch, goal,
               tests_passing, branch_ready, pr_url, pr_approved, is_stalled,
               revision_count, review_mode, blocked_reason,
-              last_output_at, state_entered_at, created_at, updated_at)
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19)
+              last_output_at, state_entered_at, created_at, updated_at, display_title)
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17,?18,?19,?20)
              ON CONFLICT(id) DO UPDATE SET
                workspace       = excluded.workspace,
                state           = excluded.state,
@@ -273,7 +278,8 @@ impl WorkerStore {
                blocked_reason  = excluded.blocked_reason,
                last_output_at  = excluded.last_output_at,
                state_entered_at= excluded.state_entered_at,
-               updated_at      = excluded.updated_at",
+               updated_at      = excluded.updated_at,
+               display_title   = COALESCE(excluded.display_title, workers.display_title)",
             params![
                 worker.id,
                 worker.workspace,
@@ -294,6 +300,7 @@ impl WorkerStore {
                 worker.state_entered_at,
                 worker.created_at,
                 worker.updated_at,
+                worker.display_title,
             ],
         )
         .wrap_err("upsert worker")?;
@@ -307,7 +314,7 @@ impl WorkerStore {
             "SELECT id,workspace,state,brief,repo,branch,goal,
                     tests_passing,branch_ready,pr_url,pr_approved,is_stalled,
                     revision_count,review_mode,blocked_reason,
-                    last_output_at,state_entered_at,created_at,updated_at
+                    last_output_at,state_entered_at,created_at,updated_at,display_title
              FROM workers WHERE workspace=?1 AND id=?2",
             params![workspace, id],
             row_to_worker,
@@ -329,7 +336,7 @@ impl WorkerStore {
             "SELECT id,workspace,state,brief,repo,branch,goal,
                     tests_passing,branch_ready,pr_url,pr_approved,is_stalled,
                     revision_count,review_mode,blocked_reason,
-                    last_output_at,state_entered_at,created_at,updated_at
+                    last_output_at,state_entered_at,created_at,updated_at,display_title
              FROM workers WHERE workspace=?1
              ORDER BY updated_at DESC",
         )?;
@@ -452,6 +459,22 @@ impl WorkerStore {
         Ok(())
     }
 
+    /// Set the LLM-generated display title for a worker.
+    pub fn update_display_title(&self, workspace: &str, id: &str, title: &str) -> Result<()> {
+        let now = Utc::now().to_rfc3339();
+        let conn = self.conn.lock().unwrap();
+        let rows = conn
+            .execute(
+                "UPDATE workers SET display_title=?1, updated_at=?2 WHERE workspace=?3 AND id=?4",
+                params![title, now, workspace, id],
+            )
+            .wrap_err("update display_title")?;
+        if rows == 0 {
+            return Err(eyre!("worker not found: {workspace}/{id}"));
+        }
+        Ok(())
+    }
+
     /// Replace a worker's UUID with the swarm-assigned ID.
     /// Deletes the old record and upserts under the new ID.
     pub fn rekey(&self, old_id: &str, new_id: &str) -> Result<()> {
@@ -493,6 +516,7 @@ fn row_to_worker(row: &rusqlite::Row<'_>) -> rusqlite::Result<Worker> {
         state_entered_at: row.get(16)?,
         created_at: row.get(17)?,
         updated_at: row.get(18)?,
+        display_title: row.get(19)?,
         // label is filled in by the caller
         label: String::new(),
     })
@@ -526,6 +550,7 @@ mod tests {
             state_entered_at: now.clone(),
             created_at: now.clone(),
             updated_at: now,
+            display_title: None,
             label: String::new(),
         }
     }

--- a/crates/apiari/src/buzz/worker_hooks.rs
+++ b/crates/apiari/src/buzz/worker_hooks.rs
@@ -459,6 +459,7 @@ mod tests {
             state_entered_at: now.clone(),
             created_at: now.clone(),
             updated_at: now,
+            display_title: None,
             label: String::new(),
         }
     }

--- a/crates/apiari/src/daemon/http.rs
+++ b/crates/apiari/src/daemon/http.rs
@@ -4607,10 +4607,18 @@ async fn generate_and_store_worker_title(
                 .map_err(|e| format!("write stdin: {e}"))?;
         }
 
-        let output = child
-            .wait_with_output()
-            .await
-            .map_err(|e| format!("wait: {e}"))?;
+        // 30-second timeout to avoid hanging tasks
+        let output = match tokio::time::timeout(
+            std::time::Duration::from_secs(30),
+            child.wait_with_output(),
+        )
+        .await
+        {
+            Ok(Ok(out)) => out,
+            Ok(Err(e)) => return Err(format!("wait: {e}")),
+            Err(_) => return Err("timeout waiting for claude".to_string()),
+        };
+
         if !output.status.success() {
             return Err("claude exited non-zero".to_string());
         }
@@ -4627,12 +4635,8 @@ async fn generate_and_store_worker_title(
             return Err("empty title from claude".to_string());
         }
 
-        // Truncate to 80 chars max
-        let title = if title.len() > 80 {
-            title[..80].to_string()
-        } else {
-            title
-        };
+        // Truncate to 80 chars on a character boundary (not byte index)
+        let title: String = title.chars().take(80).collect();
 
         let store = open_worker_store_from_path(db_path).map_err(|e| format!("open store: {e}"))?;
         store

--- a/crates/apiari/src/daemon/http.rs
+++ b/crates/apiari/src/daemon/http.rs
@@ -5069,6 +5069,7 @@ async fn v2_requeue_worker(
         state_entered_at: now.clone(),
         created_at: worker.created_at.clone(),
         updated_at: now,
+        display_title: worker.display_title.clone(),
         label: String::new(),
     };
     let _ = store.upsert(&updated_worker);
@@ -5233,6 +5234,7 @@ async fn auto_requeue_with_feedback(
         state_entered_at: now.clone(),
         created_at: worker.created_at.clone(),
         updated_at: now,
+        display_title: worker.display_title.clone(),
         label: String::new(),
     };
     let _ = store.upsert(&updated_worker);
@@ -6841,7 +6843,7 @@ mod tests {
                 topic_id: None,
                 heartbeat: None,
                 heartbeat_prompt: None,
-            token_controls: crate::config::TokenControls::default(),
+                token_controls: crate::config::TokenControls::default(),
             },
             crate::config::BeeConfig {
                 name: "Codex".to_string(),
@@ -6857,7 +6859,7 @@ mod tests {
                 topic_id: None,
                 heartbeat: None,
                 heartbeat_prompt: None,
-            token_controls: crate::config::TokenControls::default(),
+                token_controls: crate::config::TokenControls::default(),
             },
         ]);
 
@@ -6915,7 +6917,7 @@ mod tests {
                 topic_id: None,
                 heartbeat: None,
                 heartbeat_prompt: None,
-            token_controls: crate::config::TokenControls::default(),
+                token_controls: crate::config::TokenControls::default(),
             },
             crate::config::BeeConfig {
                 name: "Codex".to_string(),
@@ -6931,7 +6933,7 @@ mod tests {
                 topic_id: None,
                 heartbeat: None,
                 heartbeat_prompt: None,
-            token_controls: crate::config::TokenControls::default(),
+                token_controls: crate::config::TokenControls::default(),
             },
         ]);
 

--- a/crates/apiari/src/daemon/http.rs
+++ b/crates/apiari/src/daemon/http.rs
@@ -4573,6 +4573,14 @@ async fn v2_create_worker(
     }
 }
 
+/// Semaphore capping concurrent title-generation claude subprocesses.
+static TITLE_GEN_SEMAPHORE: std::sync::OnceLock<tokio::sync::Semaphore> =
+    std::sync::OnceLock::new();
+
+fn title_gen_semaphore() -> &'static tokio::sync::Semaphore {
+    TITLE_GEN_SEMAPHORE.get_or_init(|| tokio::sync::Semaphore::new(4))
+}
+
 /// Generate a short display title for a worker using Claude and store it in the DB.
 /// Runs as a background task; failures are silently logged.
 async fn generate_and_store_worker_title(
@@ -4583,6 +4591,15 @@ async fn generate_and_store_worker_title(
 ) {
     use tokio::io::AsyncWriteExt as _;
     use tracing::{info, warn};
+
+    // Limit concurrent claude subprocesses for title generation
+    let _permit = match title_gen_semaphore().try_acquire() {
+        Ok(p) => p,
+        Err(_) => {
+            warn!("[worker-title/{workspace}/{worker_id}] skipped: title generation at capacity");
+            return;
+        }
+    };
 
     let prompt = format!(
         "Generate a short display title (4-8 words) for this task. \

--- a/crates/apiari/src/daemon/http.rs
+++ b/crates/apiari/src/daemon/http.rs
@@ -4459,6 +4459,7 @@ async fn v2_create_worker(
         state_entered_at: now.clone(),
         created_at: now.clone(),
         updated_at: now,
+        display_title: None,
         label: String::new(),
     };
 
@@ -4533,6 +4534,23 @@ async fn v2_create_worker(
                     label: "Queued".to_string(),
                     properties: serde_json::json!({}),
                 });
+
+            // Spawn background task to generate a short display title via Claude
+            if let Some(goal_text) = goal.filter(|g| !g.is_empty()) {
+                let title_workspace = workspace.clone();
+                let title_id = final_id.clone();
+                let db_path = state.db_path.clone();
+                tokio::spawn(async move {
+                    generate_and_store_worker_title(
+                        &title_workspace,
+                        &title_id,
+                        &goal_text,
+                        &db_path,
+                    )
+                    .await;
+                });
+            }
+
             Json(serde_json::json!({
                 "ok": true,
                 "worker_id": final_id,
@@ -4552,6 +4570,82 @@ async fn v2_create_worker(
             Json(serde_json::json!({"error": format!("failed to run swarm: {e}")})),
         )
             .into_response(),
+    }
+}
+
+/// Generate a short display title for a worker using Claude and store it in the DB.
+/// Runs as a background task; failures are silently logged.
+async fn generate_and_store_worker_title(
+    workspace: &str,
+    worker_id: &str,
+    goal: &str,
+    db_path: &std::path::Path,
+) {
+    use tokio::io::AsyncWriteExt as _;
+    use tracing::{info, warn};
+
+    let prompt = format!(
+        "Generate a short display title (4-8 words) for this task. \
+         Output only the title, no punctuation, no markdown, no explanation.\n\nTask: {goal}"
+    );
+
+    let result = async {
+        let mut child = tokio::process::Command::new("claude")
+            .arg("--print")
+            .arg("--max-turns")
+            .arg("1")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .map_err(|e| format!("spawn claude: {e}"))?;
+
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin
+                .write_all(prompt.as_bytes())
+                .await
+                .map_err(|e| format!("write stdin: {e}"))?;
+        }
+
+        let output = child
+            .wait_with_output()
+            .await
+            .map_err(|e| format!("wait: {e}"))?;
+        if !output.status.success() {
+            return Err("claude exited non-zero".to_string());
+        }
+
+        let raw = String::from_utf8_lossy(&output.stdout);
+        let title = raw
+            .lines()
+            .find(|l| !l.trim().is_empty())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+
+        if title.is_empty() {
+            return Err("empty title from claude".to_string());
+        }
+
+        // Truncate to 80 chars max
+        let title = if title.len() > 80 {
+            title[..80].to_string()
+        } else {
+            title
+        };
+
+        let store = open_worker_store_from_path(db_path).map_err(|e| format!("open store: {e}"))?;
+        store
+            .update_display_title(workspace, worker_id, &title)
+            .map_err(|e| format!("update: {e}"))?;
+
+        Ok::<String, String>(title)
+    }
+    .await;
+
+    match result {
+        Ok(title) => info!("[worker-title/{workspace}/{worker_id}] generated: {title:?}"),
+        Err(e) => warn!("[worker-title/{workspace}/{worker_id}] failed: {e}"),
     }
 }
 

--- a/web/src/components/WorkerDetailV2/WorkerDetailV2.tsx
+++ b/web/src/components/WorkerDetailV2/WorkerDetailV2.tsx
@@ -621,7 +621,7 @@ export default function WorkerDetailV2({ workspace, workerId, onClose: _onClose,
         )}
         <div className={styles.headerRow}>
           <h1 className={styles.goal}>
-            {data.goal ?? data.branch ?? data.id}
+            {data.display_title ?? data.goal ?? data.branch ?? data.id}
           </h1>
           <div className={styles.headerActions}>
             {onOpenContextBot && (

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -262,6 +262,7 @@ export interface WorkerV2 {
   repo: string | null;
   branch: string | null;
   goal: string | null;
+  display_title?: string | null;
   tests_passing: boolean;
   branch_ready: boolean;
   pr_url: string | null;


### PR DESCRIPTION
## Summary

- Adds a short LLM-generated `display_title` field to workers (4-8 words), stored in the DB
- The worker detail header now shows `display_title` instead of the full goal text, reducing duplication with the Brief tab
- Title is generated asynchronously after worker creation via `claude --print --max-turns 1`; falls back to goal text if not yet available

## Test plan

- [ ] All Rust tests pass (`cargo test`)
- [ ] All frontend tests pass (`npx vitest run`)
- [ ] `cargo fmt` and `cargo clippy -D warnings` clean
- [ ] Create a new worker and verify the header shows a short generated title after a few seconds
- [ ] Verify the full goal still appears in the Brief tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)