### PR TITLE
Auto-close workers when PR is closed (not just merged)

### DIFF
--- a/crates/swarm/src/daemon/mod.rs
+++ b/crates/swarm/src/daemon/mod.rs
@@ -1989,16 +1989,17 @@ fn apply_pr_poll_results(
                 });
             }
 
-            let is_merged = result.pr.state == "MERGED";
+            let is_closed = matches!(result.pr.state.as_str(), "MERGED" | "CLOSED");
             worker.pr = Some(result.pr);
             *state_dirty = true;
 
-            // Auto-close workers whose PR has been merged (if enabled for this workspace)
-            if is_merged && ws.close_on_pr_merge {
+            // Auto-close workers whose PR has been merged or closed (if enabled for this workspace)
+            if is_closed && ws.close_on_pr_merge {
                 tracing::info!(
                     worker_id = %worker.id,
                     pr_number = worker.pr.as_ref().unwrap().number,
-                    "Auto-closing worker, PR merged",
+                    pr_state = %worker.pr.as_ref().unwrap().state,
+                    "Auto-closing worker, PR merged or closed",
                 );
                 worker.message_tx = None;
                 worker.phase = WorkerPhase::Completed;
@@ -2507,6 +2508,44 @@ mod tests {
                 title: "merged pr".to_string(),
                 state: "MERGED".to_string(),
                 url: "https://github.com/test/repo/pull/42".to_string(),
+            },
+            is_new: false,
+        }];
+
+        let mut state_dirty = false;
+        let (event_tx, mut event_rx) = broadcast::channel(16);
+        apply_pr_poll_results(results, &mut workspaces, &mut state_dirty, &event_tx);
+
+        // Worker should be removed from workspace
+        assert!(workspaces.get(&ws_path).unwrap().workers.is_empty());
+        assert!(state_dirty);
+
+        // Should have broadcast a StateChanged event
+        let event = event_rx.try_recv().unwrap();
+        match event {
+            DaemonResponse::StateChanged { worktree_id, phase } => {
+                assert_eq!(worktree_id, "w-1");
+                assert_eq!(phase, WorkerPhase::Completed);
+            }
+            other => panic!("expected StateChanged, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn apply_pr_poll_results_auto_closes_closed_pr() {
+        let mut workspaces = HashMap::new();
+        let ws_path = PathBuf::from("/tmp/ws");
+        let ws = test_workspace("/tmp/ws", vec!["w-1"]);
+        workspaces.insert(ws_path.clone(), ws);
+
+        let results = vec![PrPollResult {
+            worker_id: "w-1".to_string(),
+            workspace_path: ws_path.clone(),
+            pr: PrInfo {
+                number: 43,
+                title: "closed pr".to_string(),
+                state: "CLOSED".to_string(),
+                url: "https://github.com/test/repo/pull/43".to_string(),
             },
             is_new: false,
         }];


### PR DESCRIPTION
## Summary

- Extends `apply_pr_poll_results` to treat `pr.state == "CLOSED"` the same as `"MERGED"` for auto-close purposes
- Workers with closed/abandoned PRs are now cleaned up (worktree removed, branch deleted) instead of sitting idle in the sidebar
- The `close_on_pr_merge` config flag continues to gate both behaviors

## Test plan
- [ ] New test `apply_pr_poll_results_auto_closes_closed_pr` verifies a CLOSED PR triggers worker removal and `StateChanged` event
- [ ] Existing merged/disabled tests still pass (6/6 PR poll tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)