### PR TITLE
Auto-close workers when PR is CLOSED, not just MERGED

### DIFF
--- a/crates/swarm/src/daemon/mod.rs
+++ b/crates/swarm/src/daemon/mod.rs
@@ -1990,15 +1990,16 @@ fn apply_pr_poll_results(
             }
 
             let is_merged = result.pr.state == "MERGED";
+            let is_closed = result.pr.state == "CLOSED";
             worker.pr = Some(result.pr);
             *state_dirty = true;
 
-            // Auto-close workers whose PR has been merged (if enabled for this workspace)
-            if is_merged && ws.close_on_pr_merge {
+            // Auto-close workers whose PR has been merged or closed (if enabled for this workspace)
+            if (is_merged || is_closed) && ws.close_on_pr_merge {
                 tracing::info!(
                     worker_id = %worker.id,
                     pr_number = worker.pr.as_ref().unwrap().number,
-                    "Auto-closing worker, PR merged",
+                    "Auto-closing worker, PR merged or closed",
                 );
                 worker.message_tx = None;
                 worker.phase = WorkerPhase::Completed;
@@ -2506,6 +2507,44 @@ mod tests {
                 number: 42,
                 title: "merged pr".to_string(),
                 state: "MERGED".to_string(),
+                url: "https://github.com/test/repo/pull/42".to_string(),
+            },
+            is_new: false,
+        }];
+
+        let mut state_dirty = false;
+        let (event_tx, mut event_rx) = broadcast::channel(16);
+        apply_pr_poll_results(results, &mut workspaces, &mut state_dirty, &event_tx);
+
+        // Worker should be removed from workspace
+        assert!(workspaces.get(&ws_path).unwrap().workers.is_empty());
+        assert!(state_dirty);
+
+        // Should have broadcast a StateChanged event
+        let event = event_rx.try_recv().unwrap();
+        match event {
+            DaemonResponse::StateChanged { worktree_id, phase } => {
+                assert_eq!(worktree_id, "w-1");
+                assert_eq!(phase, WorkerPhase::Completed);
+            }
+            other => panic!("expected StateChanged, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn apply_pr_poll_results_auto_closes_closed_pr() {
+        let mut workspaces = HashMap::new();
+        let ws_path = PathBuf::from("/tmp/ws");
+        let ws = test_workspace("/tmp/ws", vec!["w-1"]);
+        workspaces.insert(ws_path.clone(), ws);
+
+        let results = vec![PrPollResult {
+            worker_id: "w-1".to_string(),
+            workspace_path: ws_path.clone(),
+            pr: PrInfo {
+                number: 42,
+                title: "closed pr".to_string(),
+                state: "CLOSED".to_string(),
                 url: "https://github.com/test/repo/pull/42".to_string(),
             },
             is_new: false,


### PR DESCRIPTION
## Summary
- Extended auto-close logic in `apply_pr_poll_results()` to trigger on `pr.state == "CLOSED"` in addition to `"MERGED"`
- Workers with closed PRs were previously left sitting with their worktrees intact, taking up disk space and cluttering the sidebar
- Added a test case `apply_pr_poll_results_auto_closes_closed_pr` to verify the new behavior

## Test plan
- [ ] All existing `apply_pr_poll_results` tests still pass
- [ ] New test `apply_pr_poll_results_auto_closes_closed_pr` passes
- [ ] Verify a worker whose PR is manually closed via GitHub UI gets auto-cleaned up

🤖 Generated with [Claude Code](https://claude.com/claude-code)