### PR TITLE
fix: use prompt titles in worker lists

### DIFF
--- a/crates/apiari/src/daemon/http.rs
+++ b/crates/apiari/src/daemon/http.rs
@@ -1722,17 +1722,13 @@ fn worker_repo_name(
 
 fn worker_task_title(worker: &SwarmWorktreeState) -> String {
     worker
-        .summary
-        .clone()
-        .or_else(|| {
-            worker
-                .prompt
-                .lines()
-                .next()
-                .map(str::trim)
-                .filter(|line| !line.is_empty())
-                .map(str::to_string)
-        })
+        .prompt
+        .lines()
+        .next()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(str::to_string)
+        .or_else(|| worker.summary.clone())
         .unwrap_or_else(|| format!("Worker {}", worker.id))
 }
 
@@ -3090,10 +3086,7 @@ fn worker_view_from_state(
             .as_ref()
             .and_then(|pr| pr.title.clone())
             .or(overlay_pr_title),
-        description: worker
-            .summary
-            .clone()
-            .or_else(|| (!worker.prompt.trim().is_empty()).then(|| worker.prompt.clone())),
+        description: Some(worker_task_title(worker)),
         elapsed_secs: elapsed_secs(worker.created_at),
         dispatched_by: None,
         review_state: worker.pr.as_ref().and_then(|pr| pr.state.clone()),
@@ -7502,6 +7495,33 @@ state_path = "{}"
         assert_eq!(
             workers[0].execution_note.as_deref(),
             Some("Uncommitted diff, no ready branch, and no active session.")
+        );
+    }
+
+    #[test]
+    fn worker_task_title_prefers_prompt_over_summary() {
+        let worker = SwarmWorktreeState {
+            id: "apiari-7a04".to_string(),
+            branch: "swarm/mobile-cards".to_string(),
+            prompt: "Tighten mobile cards in the workers list.\nUse the prompt wording."
+                .to_string(),
+            agent_kind: "codex".to_string(),
+            created_at: None,
+            summary: Some("AI-generated summary".to_string()),
+            pr: None,
+            phase: None,
+            agent_session_status: None,
+            repo_path: None,
+            worktree_path: None,
+            agent_pid: None,
+            session_id: None,
+            ready_branch: None,
+            failure_note: None,
+        };
+
+        assert_eq!(
+            worker_task_title(&worker),
+            "Tighten mobile cards in the workers list."
         );
     }
 

--- a/web/src/__tests__/WorkersPanel.test.tsx
+++ b/web/src/__tests__/WorkersPanel.test.tsx
@@ -35,15 +35,17 @@ const workers: Worker[] = [
 ];
 
 describe("WorkersPanel", () => {
-  it("shows derived lifecycle and latest attempt on worker cards", () => {
+  it("shows task titles as the primary worker label", () => {
     const onSelectWorker = vi.fn();
     render(<WorkersPanel workers={workers} onSelectWorker={onSelectWorker} />);
 
+    expect(screen.getByText("Tighten mobile cards")).toBeInTheDocument();
+    expect(screen.getByText("apiari-ebbc · mobile-cards")).toBeInTheDocument();
     expect(screen.getByText("Ready")).toBeInTheDocument();
     expect(screen.getByText("Implementation failed")).toBeInTheDocument();
     expect(screen.getByText("Worker closed without PR")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText("apiari-ebbc"));
+    fireEvent.click(screen.getByText("Tighten mobile cards"));
     expect(onSelectWorker).toHaveBeenCalledWith("apiari-ebbc");
   });
 });

--- a/web/src/components/OverviewPanel.tsx
+++ b/web/src/components/OverviewPanel.tsx
@@ -46,6 +46,10 @@ function previewLabel(content?: string | null) {
   return content.length > 84 ? `${content.slice(0, 84).trimEnd()}…` : content;
 }
 
+function workerListTitle(worker: Worker) {
+  return worker.task_title || worker.description || worker.branch.replace(/^swarm\//, "");
+}
+
 export function OverviewPanel({
   workspace,
   remote,
@@ -125,7 +129,7 @@ export function OverviewPanel({
     nextWorker
       ? {
           key: `worker-${nextWorker.id}`,
-          title: `Review ${nextWorker.id}`,
+          title: workerListTitle(nextWorker),
           meta: `${nextWorker.status} · ${nextWorker.branch.replace(/^swarm\//, "")}`,
           action: () => onSelectWorker(nextWorker.id),
         }
@@ -225,7 +229,7 @@ export function OverviewPanel({
                 <ObjectRow
                   key={`worker-${worker.id}`}
                   onClick={() => onSelectWorker(worker.id)}
-                  title={worker.id}
+                  title={workerListTitle(worker)}
                   meta={`${worker.status} · ${worker.branch.replace(/^swarm\//, "")}`}
                   right={<StatusBadge tone="success">worker</StatusBadge>}
                 />
@@ -299,7 +303,7 @@ export function OverviewPanel({
                 <ObjectRow
                   key={worker.id}
                   onClick={() => onSelectWorker(worker.id)}
-                  title={worker.id}
+                  title={workerListTitle(worker)}
                   meta={`${worker.status} · ${worker.branch.replace(/^swarm\//, "")}`}
                   right={(
                     <>

--- a/web/src/components/WorkersPanel.tsx
+++ b/web/src/components/WorkersPanel.tsx
@@ -23,6 +23,10 @@ function branchName(branch: string): string {
   return branch.replace(/^swarm\//, "");
 }
 
+function workerListTitle(worker: Worker): string {
+  return worker.task_title || worker.description || branchName(worker.branch);
+}
+
 function labelForAttemptRole(role?: string | null): string | null {
   if (!role) return null;
   if (role === "implementation") return "Implementation";
@@ -65,13 +69,13 @@ export function WorkersPanel({ workers, onSelectWorker, mobileOpen, onClose }: P
                       : "var(--text-faint)",
               }}
             />
-            <span className={styles.id}>{w.id}</span>
+            <span className={styles.id}>{workerListTitle(w)}</span>
             <span className={styles.time}>
               {formatElapsed(w.elapsed_secs)}
             </span>
           </div>
           <div className={styles.desc}>
-            {w.task_title || w.description || branchName(w.branch)}
+            {w.id} · {branchName(w.branch)}
           </div>
           <div className={styles.tags}>
             {w.status === "stalled" && (


### PR DESCRIPTION
## Summary
- show task/prompt titles as the primary label in legacy worker lists
- keep worker ids as secondary metadata in the workers panel
- prefer the original prompt line over AI-generated summaries when deriving worker display titles

## Verification
- cargo test worker_task_title_prefers_prompt_over_summary -p apiari
- npx vitest run src/__tests__/WorkersPanel.test.tsx