### PR TITLE
fix: show worker prompts in list

### DIFF
--- a/crates/apiari/src/daemon/http.rs
+++ b/crates/apiari/src/daemon/http.rs
@@ -2739,6 +2739,8 @@ struct WorkerView {
     agent: String,
     status: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    prompt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     execution_note: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     ready_branch: Option<String>,
@@ -3014,6 +3016,7 @@ fn worker_view_from_task(workspace: &str, task: &crate::buzz::task::Task) -> Opt
             .unwrap_or_else(|| "task/lifecycle".to_string()),
         agent: "system".to_string(),
         status: worker_status_for_task(task),
+        prompt: None,
         execution_note: None,
         ready_branch: None,
         has_uncommitted_changes: false,
@@ -3070,6 +3073,7 @@ fn worker_view_from_state(
             worker.agent_kind.clone()
         },
         status: overlay_status.unwrap_or_else(|| worker_status_for_state(config, worker)),
+        prompt: (!worker.prompt.trim().is_empty()).then(|| worker.prompt.clone()),
         execution_note: worker_execution_note(config, worker),
         ready_branch: worker.ready_branch.clone(),
         has_uncommitted_changes: worker_has_uncommitted_changes(worker),
@@ -6990,6 +6994,7 @@ mod tests {
                 branch: "apiari/fix-http".to_string(),
                 agent: "claude".to_string(),
                 status: "running".to_string(),
+                prompt: None,
                 execution_note: None,
                 ready_branch: None,
                 has_uncommitted_changes: false,
@@ -7016,6 +7021,7 @@ mod tests {
                 branch: "common/fix-sdk".to_string(),
                 agent: "gemini".to_string(),
                 status: "running".to_string(),
+                prompt: None,
                 execution_note: None,
                 ready_branch: None,
                 has_uncommitted_changes: false,

--- a/web/src/__tests__/WorkersPanel.test.tsx
+++ b/web/src/__tests__/WorkersPanel.test.tsx
@@ -9,6 +9,7 @@ const workers: Worker[] = [
     branch: "swarm/mobile-cards",
     status: "failed",
     agent: "codex",
+    prompt: "Use the original prompt text in the worker list",
     execution_note: "Worker finished without a ready branch or PR handoff.",
     ready_branch: null,
     has_uncommitted_changes: false,
@@ -39,6 +40,10 @@ describe("WorkersPanel", () => {
     const onSelectWorker = vi.fn();
     render(<WorkersPanel workers={workers} onSelectWorker={onSelectWorker} />);
 
+    expect(
+      screen.getByText("Use the original prompt text in the worker list"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Tighten mobile cards")).not.toBeInTheDocument();
     expect(screen.getByText("Ready")).toBeInTheDocument();
     expect(screen.getByText("Implementation failed")).toBeInTheDocument();
     expect(screen.getByText("Worker closed without PR")).toBeInTheDocument();

--- a/web/src/components/WorkersPanel.tsx
+++ b/web/src/components/WorkersPanel.tsx
@@ -71,7 +71,7 @@ export function WorkersPanel({ workers, onSelectWorker, mobileOpen, onClose }: P
             </span>
           </div>
           <div className={styles.desc}>
-            {w.task_title || w.description || branchName(w.branch)}
+            {w.prompt || w.description || w.task_title || branchName(w.branch)}
           </div>
           <div className={styles.tags}>
             {w.status === "stalled" && (

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -20,6 +20,7 @@ export interface Worker {
   branch: string;
   status: string;
   agent: string;
+  prompt?: string | null;
   execution_note?: string | null;
   ready_branch?: string | null;
   has_uncommitted_changes?: boolean;


### PR DESCRIPTION
## Summary
- expose the raw worker prompt on the worker list payload
- prefer the prompt over generated task titles in the workers panel
- cover the change with a focused workers panel test

## Testing
- cargo test -p apiari get_workspace_workers -- --nocapture
- cd web && npx vitest run -c vitest.config.ts src/__tests__/WorkersPanel.test.tsx