### PR TITLE
fix: show prompt text first in worker lists

### DIFF
--- a/web/src/__tests__/ReposPanel.test.tsx
+++ b/web/src/__tests__/ReposPanel.test.tsx
@@ -7,7 +7,7 @@ import type { Repo, ResearchTask } from "../types";
 const repos: Repo[] = [
   { name: "hive", path: "/dev/hive", has_swarm: true, is_clean: true, branch: "main", workers: [] },
   { name: "swarm", path: "/dev/swarm", has_swarm: true, is_clean: false, branch: "feat/test", workers: [
-    { id: "cli-3", branch: "swarm/fix-bug", status: "running", agent: "claude", pr_url: "https://github.com/test/pull/1", pr_title: "Fix bug", description: null, elapsed_secs: 120, dispatched_by: "Main" },
+    { id: "cli-3", branch: "swarm/fix-bug", status: "running", agent: "claude", pr_url: "https://github.com/test/pull/1", pr_title: "Fix bug", description: "Fix login race", elapsed_secs: 120, dispatched_by: "Main" },
   ]},
   { name: "common", path: "/dev/common", has_swarm: false, is_clean: true, branch: "main", workers: [] },
 ];
@@ -46,6 +46,7 @@ describe("ReposPanel", () => {
 
   it("renders workers under their repo", () => {
     render(<ReposPanel {...defaultProps} />);
+    expect(screen.getByText("Fix login race")).toBeInTheDocument();
     expect(screen.getByText("cli-3")).toBeInTheDocument();
   });
 
@@ -58,7 +59,7 @@ describe("ReposPanel", () => {
     const user = userEvent.setup();
     const onSelect = vi.fn();
     render(<ReposPanel {...defaultProps} onSelectWorker={onSelect} />);
-    await user.click(screen.getByText("cli-3"));
+    await user.click(screen.getByText("Fix login race"));
     expect(onSelect).toHaveBeenCalledWith("cli-3");
   });
 

--- a/web/src/__tests__/WorkersPanel.test.tsx
+++ b/web/src/__tests__/WorkersPanel.test.tsx
@@ -39,11 +39,13 @@ describe("WorkersPanel", () => {
     const onSelectWorker = vi.fn();
     render(<WorkersPanel workers={workers} onSelectWorker={onSelectWorker} />);
 
+    expect(screen.getByText("Tighten mobile cards")).toBeInTheDocument();
+    expect(screen.getByText("apiari-ebbc")).toBeInTheDocument();
     expect(screen.getByText("Ready")).toBeInTheDocument();
     expect(screen.getByText("Implementation failed")).toBeInTheDocument();
     expect(screen.getByText("Worker closed without PR")).toBeInTheDocument();
 
-    fireEvent.click(screen.getByText("apiari-ebbc"));
+    fireEvent.click(screen.getByText("Tighten mobile cards"));
     expect(onSelectWorker).toHaveBeenCalledWith("apiari-ebbc");
   });
 });

--- a/web/src/components/ReposPanel.module.css
+++ b/web/src/components/ReposPanel.module.css
@@ -96,6 +96,15 @@
   color: var(--text-strong);
 }
 
+.workerTitleLine {
+  font-size: 13px;
+  color: var(--text);
+  margin-top: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .workerBranchLine {
   font-size: 12px;
   color: var(--text-faint);

--- a/web/src/components/ReposPanel.tsx
+++ b/web/src/components/ReposPanel.tsx
@@ -17,6 +17,10 @@ function branchName(branch: string): string {
   return branch.replace(/^swarm\//, "");
 }
 
+function workerLabel(worker: Repo["workers"][number]): string {
+  return worker.task_title || worker.description || branchName(worker.branch);
+}
+
 export function ReposPanel({ repos, researchTasks, onSelectWorker, mobileOpen, onClose }: Props) {
   return (
     <ToolPanel
@@ -81,7 +85,10 @@ export function ReposPanel({ repos, researchTasks, onSelectWorker, mobileOpen, o
                         </span>
                       )}
                     </div>
-                    <div className={styles.workerBranchLine}>{branchName(w.branch)}</div>
+                    <div className={styles.workerTitleLine}>{workerLabel(w)}</div>
+                    <div className={styles.workerBranchLine}>
+                      {w.id} · {branchName(w.branch)}
+                    </div>
                   </div>
                 ))}
               </div>

--- a/web/src/components/WorkersPanel.module.css
+++ b/web/src/components/WorkersPanel.module.css
@@ -31,7 +31,7 @@
   animation: pulse 2s infinite;
 }
 
-.id {
+.title {
   font-size: 15px;
   font-weight: 600;
   color: var(--text-strong);

--- a/web/src/components/WorkersPanel.tsx
+++ b/web/src/components/WorkersPanel.tsx
@@ -23,6 +23,10 @@ function branchName(branch: string): string {
   return branch.replace(/^swarm\//, "");
 }
 
+function workerLabel(worker: Worker): string {
+  return worker.task_title || worker.description || branchName(worker.branch);
+}
+
 function labelForAttemptRole(role?: string | null): string | null {
   if (!role) return null;
   if (role === "implementation") return "Implementation";
@@ -65,13 +69,13 @@ export function WorkersPanel({ workers, onSelectWorker, mobileOpen, onClose }: P
                       : "var(--text-faint)",
               }}
             />
-            <span className={styles.id}>{w.id}</span>
+            <span className={styles.title}>{workerLabel(w)}</span>
             <span className={styles.time}>
               {formatElapsed(w.elapsed_secs)}
             </span>
           </div>
           <div className={styles.desc}>
-            {w.task_title || w.description || branchName(w.branch)}
+            {w.id}
           </div>
           <div className={styles.tags}>
             {w.status === "stalled" && (


### PR DESCRIPTION
## Summary
- make worker list rows lead with prompt-derived task text instead of the generated worker id
- keep the worker id visible as secondary metadata in workers and repo panels
- update the targeted frontend tests to cover the new labeling

## Verification
- ./node_modules/.bin/vitest run src/__tests__/WorkersPanel.test.tsx src/__tests__/ReposPanel.test.tsx
- ./node_modules/.bin/tsc --noEmit
