### PR TITLE
fix: show full coordinator task packet in worker brief

### DIFF
--- a/crates/apiari/src/daemon/http.rs
+++ b/crates/apiari/src/daemon/http.rs
@@ -4247,10 +4247,18 @@ async fn v2_get_worker(
     } else {
         vec![]
     };
+    let task_packet = worker
+        .worktree_path
+        .as_deref()
+        .map(std::path::Path::new)
+        .and_then(read_worker_task_packet);
 
     let mut response = serde_json::to_value(&worker).unwrap_or_default();
     if let Some(obj) = response.as_object_mut() {
         obj.insert("events".to_string(), serde_json::json!(events));
+        if let Some(task_packet) = task_packet {
+            obj.insert("task_packet".to_string(), serde_json::json!(task_packet));
+        }
     }
     Json(response).into_response()
 }
@@ -9225,6 +9233,77 @@ model = "sonnet"
 
         // Transition on a missing worker returns error (not 404 — store returns Err).
         assert_ne!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn v2_get_worker_includes_task_packet_from_worktree() {
+        let _env_guard = env_lock();
+        let temp = tempfile::tempdir().unwrap();
+        let _home_guard = install_temp_home(temp.path());
+        let root = temp.path().join("ws");
+        let worktree = root.join(".swarm/wt/w-1");
+        let task_dir = worktree.join(".task");
+        fs::create_dir_all(&task_dir).unwrap();
+        write_minimal_workspace(temp.path(), "ws", &root);
+        fs::write(
+            task_dir.join("TASK.md"),
+            "# Task\n\nShip the full coordinator packet.\n",
+        )
+        .unwrap();
+        fs::write(
+            task_dir.join("PLAN.md"),
+            "# Plan\n\n1. Return task_packet in v2 detail\n",
+        )
+        .unwrap();
+
+        let db_path = temp.path().join("test.db");
+        let store = open_worker_store_from_path(&db_path).unwrap();
+        store
+            .upsert(&crate::buzz::worker::Worker {
+                id: "w-1".to_string(),
+                workspace: "ws".to_string(),
+                state: crate::buzz::worker::WorkerState::Running,
+                brief: Some(serde_json::json!({"goal": "ship it"})),
+                repo: Some("apiari".to_string()),
+                branch: Some("swarm/ship-it".to_string()),
+                goal: Some("ship it".to_string()),
+                tests_passing: false,
+                branch_ready: false,
+                pr_url: None,
+                pr_approved: false,
+                is_stalled: false,
+                revision_count: 0,
+                review_mode: "local_first".to_string(),
+                blocked_reason: None,
+                display_title: None,
+                last_output_at: None,
+                state_entered_at: chrono::Utc::now().to_rfc3339(),
+                created_at: chrono::Utc::now().to_rfc3339(),
+                updated_at: chrono::Utc::now().to_rfc3339(),
+                worktree_path: Some(worktree.display().to_string()),
+                isolation_mode: None,
+                agent_kind: None,
+                repo_path: Some(root.display().to_string()),
+                label: String::new(),
+            })
+            .unwrap();
+
+        let state = make_test_state_with_db(&db_path);
+        let resp = v2_get_worker(Path(("ws".to_string(), "w-1".to_string())), State(state))
+            .await
+            .into_response();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let json = response_json(resp).await;
+        assert_eq!(
+            json["task_packet"]["task_md"].as_str(),
+            Some("# Task\n\nShip the full coordinator packet.\n")
+        );
+        assert_eq!(
+            json["task_packet"]["plan_md"].as_str(),
+            Some("# Plan\n\n1. Return task_packet in v2 detail\n")
+        );
     }
 
     // ── v2_create_worker ──────────────────────────────────────────────────

--- a/web/src/__tests__/WorkerDetailV2.test.tsx
+++ b/web/src/__tests__/WorkerDetailV2.test.tsx
@@ -242,6 +242,29 @@ describe("WorkerDetailV2", () => {
     expect(screen.getByText("Works end to end")).toBeInTheDocument();
   });
 
+  it("Brief tab renders coordinator task packet sections", async () => {
+    vi.mocked(api.getWorkerV2).mockResolvedValue({
+      ...mockWorker,
+      task_packet: {
+        worker_mode: "implementation",
+        task_md: "# Task\n\nShip the worker brief panel.\n",
+        context_md: "# Context\n\n- Worker detail view\n",
+        plan_md: "# Plan\n\n1. Add API field\n",
+        shaping_md: "# Coordinator Shaping\n\nInclude the full task packet.\n",
+        progress_md: "# Progress\n\n- Wired through UI\n",
+      },
+    });
+    render(<WorkerDetailV2 workspace="default" workerId="w-abc" />);
+    await screen.findByTestId("status-badge");
+    fireEvent.click(screen.getByTestId("tab-brief"));
+    expect(await screen.findByText("implementation")).toBeInTheDocument();
+    expect(screen.getByText(/Ship the worker brief panel\./)).toBeInTheDocument();
+    expect(screen.getByText(/Worker detail view/)).toBeInTheDocument();
+    expect(screen.getByText(/Add API field/)).toBeInTheDocument();
+    expect(screen.getByText(/Include the full task packet\./)).toBeInTheDocument();
+    expect(screen.getByText(/Wired through UI/)).toBeInTheDocument();
+  });
+
   // ── Input state tests ─────────────────────────────────────────────────────
 
   it("input is enabled with async placeholder when state is running", async () => {

--- a/web/src/components/WorkerDetailV2/WorkerDetailV2.tsx
+++ b/web/src/components/WorkerDetailV2/WorkerDetailV2.tsx
@@ -378,7 +378,157 @@ function BriefSection({ label, children }: { label: string; children: React.Reac
 }
 
 function BriefMarkdown({ content }: { content: string }) {
-  return <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gap: '0.75rem',
+        minWidth: 0,
+      }}
+    >
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          p: ({ node: _node, ...props }) => (
+            <p
+              style={{
+                margin: 0,
+                lineHeight: 1.6,
+              }}
+              {...props}
+            />
+          ),
+          ul: ({ node: _node, ...props }) => (
+            <ul
+              style={{
+                margin: 0,
+                paddingLeft: '1.5rem',
+                display: 'grid',
+                gap: '0.375rem',
+              }}
+              {...props}
+            />
+          ),
+          ol: ({ node: _node, ...props }) => (
+            <ol
+              style={{
+                margin: 0,
+                paddingLeft: '1.5rem',
+                display: 'grid',
+                gap: '0.375rem',
+              }}
+              {...props}
+            />
+          ),
+          li: ({ node: _node, ...props }) => (
+            <li
+              style={{
+                margin: 0,
+              }}
+              {...props}
+            />
+          ),
+          h1: ({ node: _node, ...props }) => (
+            <h1
+              style={{
+                margin: 0,
+                fontSize: '1.25rem',
+                lineHeight: 1.3,
+              }}
+              {...props}
+            />
+          ),
+          h2: ({ node: _node, ...props }) => (
+            <h2
+              style={{
+                margin: 0,
+                fontSize: '1.125rem',
+                lineHeight: 1.35,
+              }}
+              {...props}
+            />
+          ),
+          h3: ({ node: _node, ...props }) => (
+            <h3
+              style={{
+                margin: 0,
+                fontSize: '1rem',
+                lineHeight: 1.4,
+              }}
+              {...props}
+            />
+          ),
+          h4: ({ node: _node, ...props }) => (
+            <h4
+              style={{
+                margin: 0,
+                fontSize: '0.95rem',
+                lineHeight: 1.4,
+              }}
+              {...props}
+            />
+          ),
+          blockquote: ({ node: _node, ...props }) => (
+            <blockquote
+              style={{
+                margin: 0,
+                paddingLeft: '1rem',
+                borderLeft: '3px solid rgba(148, 163, 184, 0.5)',
+                color: 'inherit',
+                opacity: 0.9,
+              }}
+              {...props}
+            />
+          ),
+          pre: ({ node: _node, ...props }) => (
+            <pre
+              style={{
+                margin: 0,
+                padding: '0.75rem',
+                overflowX: 'auto',
+                whiteSpace: 'pre',
+                borderRadius: '0.5rem',
+                background: 'rgba(15, 23, 42, 0.06)',
+              }}
+              {...props}
+            />
+          ),
+          code: ({ node: _node, inline, className, children, ...props }) =>
+            inline ? (
+              <code
+                className={className}
+                style={{
+                  padding: '0.125rem 0.375rem',
+                  borderRadius: '0.375rem',
+                  background: 'rgba(15, 23, 42, 0.06)',
+                  wordBreak: 'break-word',
+                }}
+                {...props}
+              >
+                {children}
+              </code>
+            ) : (
+              <code className={className} {...props}>
+                {children}
+              </code>
+            ),
+          hr: ({ node: _node, ...props }) => (
+            <hr
+              style={{
+                width: '100%',
+                margin: 0,
+                border: 0,
+                borderTop: '1px solid rgba(148, 163, 184, 0.35)',
+              }}
+              {...props}
+            />
+          ),
+        }}
+      >
+        {content}
+      </ReactMarkdown>
+    </div>
+  )
 }
 
 function BriefTab({

--- a/web/src/components/WorkerDetailV2/WorkerDetailV2.tsx
+++ b/web/src/components/WorkerDetailV2/WorkerDetailV2.tsx
@@ -2,7 +2,15 @@ import { useEffect, useRef, useState, useCallback } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { ExternalLink, MessageSquare, ArrowUp, ChevronLeft } from 'lucide-react'
-import type { WorkerDetailV2 as WorkerDetailV2Data, WorkerV2, WorkerReview, WorkerBrief, ContextBotContext, WorkerEvent } from '../../types'
+import type {
+  WorkerDetailV2 as WorkerDetailV2Data,
+  WorkerV2,
+  WorkerReview,
+  WorkerBrief,
+  WorkerTaskPacket,
+  ContextBotContext,
+  WorkerEvent,
+} from '../../types'
 import { getWorkerV2, sendWorkerMessageV2, cancelWorkerV2, requeueWorkerV2, requestWorkerReview, listWorkerReviews } from '../../api'
 import styles from './WorkerDetailV2.module.css'
 
@@ -369,8 +377,29 @@ function BriefSection({ label, children }: { label: string; children: React.Reac
   )
 }
 
-function BriefTab({ brief, goal }: { brief: WorkerBrief | null; goal: string | null }) {
-  if (!brief) {
+function BriefMarkdown({ content }: { content: string }) {
+  return <ReactMarkdown remarkPlugins={[remarkGfm]}>{content}</ReactMarkdown>
+}
+
+function BriefTab({
+  brief,
+  goal,
+  taskPacket,
+}: {
+  brief: WorkerBrief | null
+  goal: string | null
+  taskPacket?: WorkerTaskPacket | null
+}) {
+  const hasTaskPacket = Boolean(
+    taskPacket?.task_md ||
+    taskPacket?.context_md ||
+    taskPacket?.shaping_md ||
+    taskPacket?.plan_md ||
+    taskPacket?.progress_md ||
+    taskPacket?.worker_mode,
+  )
+
+  if (!brief && !hasTaskPacket) {
     return (
       <div className={styles.briefEmpty}>
         No brief recorded for this worker.
@@ -380,33 +409,73 @@ function BriefTab({ brief, goal }: { brief: WorkerBrief | null; goal: string | n
 
   return (
     <div className={styles.briefBody}>
-      <BriefSection label="Goal">
-        <p>{brief.goal ?? goal}</p>
-      </BriefSection>
+      {brief && (
+        <>
+          <BriefSection label="Goal">
+            <p>{brief.goal ?? goal}</p>
+          </BriefSection>
 
-      {brief.context?.recent_changes && (
-        <BriefSection label="Context">
-          <p>{brief.context.recent_changes}</p>
+          {brief.context?.recent_changes && (
+            <BriefSection label="Context">
+              <p>{brief.context.recent_changes}</p>
+            </BriefSection>
+          )}
+
+          {brief.constraints && brief.constraints.length > 0 && (
+            <BriefSection label="Constraints">
+              <ul className={styles.briefList}>
+                {brief.constraints.map((c, i) => (
+                  <li key={i}>{c}</li>
+                ))}
+              </ul>
+            </BriefSection>
+          )}
+
+          {brief.acceptance_criteria && brief.acceptance_criteria.length > 0 && (
+            <BriefSection label="Acceptance Criteria">
+              <ul className={styles.briefList}>
+                {brief.acceptance_criteria.map((c, i) => (
+                  <li key={i}>{c}</li>
+                ))}
+              </ul>
+            </BriefSection>
+          )}
+        </>
+      )}
+
+      {taskPacket?.worker_mode && (
+        <BriefSection label="Worker Mode">
+          <p>{taskPacket.worker_mode}</p>
         </BriefSection>
       )}
 
-      {brief.constraints && brief.constraints.length > 0 && (
-        <BriefSection label="Constraints">
-          <ul className={styles.briefList}>
-            {brief.constraints.map((c, i) => (
-              <li key={i}>{c}</li>
-            ))}
-          </ul>
+      {taskPacket?.task_md && (
+        <BriefSection label="Inherited Task">
+          <BriefMarkdown content={taskPacket.task_md} />
         </BriefSection>
       )}
 
-      {brief.acceptance_criteria && brief.acceptance_criteria.length > 0 && (
-        <BriefSection label="Acceptance Criteria">
-          <ul className={styles.briefList}>
-            {brief.acceptance_criteria.map((c, i) => (
-              <li key={i}>{c}</li>
-            ))}
-          </ul>
+      {taskPacket?.context_md && (
+        <BriefSection label="Inherited Context">
+          <BriefMarkdown content={taskPacket.context_md} />
+        </BriefSection>
+      )}
+
+      {taskPacket?.shaping_md && (
+        <BriefSection label="Coordinator Shaping">
+          <BriefMarkdown content={taskPacket.shaping_md} />
+        </BriefSection>
+      )}
+
+      {taskPacket?.plan_md && (
+        <BriefSection label="Execution Plan">
+          <BriefMarkdown content={taskPacket.plan_md} />
+        </BriefSection>
+      )}
+
+      {taskPacket?.progress_md && (
+        <BriefSection label="Worker Notes">
+          <BriefMarkdown content={taskPacket.progress_md} />
         </BriefSection>
       )}
     </div>
@@ -871,7 +940,7 @@ export default function WorkerDetailV2({ workspace, workerId, onClose: _onClose,
 
         {activeTab === 'brief' && (
           <div className={styles.briefPanel}>
-            <BriefTab brief={data.brief} goal={data.goal} />
+            <BriefTab brief={data.brief} goal={data.goal} taskPacket={data.task_packet} />
           </div>
         )}
       </div>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -115,14 +115,7 @@ export interface WorkerDetail extends Worker {
   prompt: string | null;
   output: string | null;
   conversation: WorkerMessage[];
-  task_packet?: {
-    worker_mode?: string | null;
-    task_md?: string | null;
-    context_md?: string | null;
-    plan_md?: string | null;
-    shaping_md?: string | null;
-    progress_md?: string | null;
-  } | null;
+  task_packet?: WorkerTaskPacket | null;
 }
 
 export interface WorkerMessage {
@@ -285,8 +278,18 @@ export interface WorkerEvent {
   input?: Record<string, unknown>;
 }
 
+export interface WorkerTaskPacket {
+  worker_mode?: string | null;
+  task_md?: string | null;
+  context_md?: string | null;
+  plan_md?: string | null;
+  shaping_md?: string | null;
+  progress_md?: string | null;
+}
+
 export interface WorkerDetailV2 extends WorkerV2 {
   events: WorkerEvent[];
+  task_packet?: WorkerTaskPacket | null;
 }
 
 // ── Worker Review types ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- include  packet data in the v2 worker detail API response
- render the inherited task/context/shaping/plan/progress sections in the worker Brief tab
- add backend and frontend coverage for the task packet rendering path

## Verification
- npx vitest run src/__tests__/WorkerDetailV2.test.tsx
- npx tsc --noEmit
- cargo test -p apiari v2_get_worker_includes_task_packet_from_worktree
- cargo test -p apiari get_workspace_worker_detail_returns_prompt_output_and_conversation