### PR TITLE
fix: show recent workers in overview

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -368,6 +368,7 @@ export default function App() {
   const activeWorkers = workers.filter((w) => !DONE_STATES.includes(w.state))
   const doneWorkers = workers.filter((w) => DONE_STATES.includes(w.state))
   const sidebarWorkers = activeWorkers.map(workerToSidebarItem)
+  const sidebarDoneWorkers = doneWorkers.map(workerToSidebarItem)
   const sidebarAutoBots = autoBots.map(autoBotToSidebarItem)
 
   const activityItems = workers
@@ -386,6 +387,7 @@ export default function App() {
       autoBots={sidebarAutoBots}
       workers={sidebarWorkers}
       doneWorkerCount={doneWorkers.length}
+      doneWorkers={sidebarDoneWorkers}
       workspaces={workspaces}
       workspace={workspace}
       onWorkspaceChange={(ws) => { setWorkspace(ws); setSelected(null); updateHash(ws) }}
@@ -484,6 +486,7 @@ export default function App() {
             autoBots={sidebarAutoBots}
             workers={sidebarWorkers}
             doneWorkerCount={doneWorkers.length}
+            doneWorkers={sidebarDoneWorkers}
             workspaces={workspaces}
             workspace={workspace}
             onWorkspaceChange={(ws) => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import BottomTabBar from './components/BottomTabBar/BottomTabBar'
 import Dashboard from './components/Dashboard/Dashboard'
 import WorkerDetailV2 from './components/WorkerDetailV2/WorkerDetailV2'
 import AutoBotDetail from './components/AutoBotDetail/AutoBotDetail'
+import CompletedWorkersView from './components/CompletedWorkersView'
 import ContextBotManager from './components/ContextBot/ContextBotManager'
 import CommandPalette from './components/CommandPalette/CommandPalette'
 import QuickDispatch from './components/QuickDispatch/QuickDispatch'
@@ -91,6 +92,7 @@ export default function App() {
   const [workers, setWorkers] = useState<WorkerV2[]>([])
   const [autoBots, setAutoBots] = useState<AutoBot[]>([])
   const [loading, setLoading] = useState(true)
+  const [showDoneWorkers, setShowDoneWorkers] = useState(false)
   const [contextSessions, setContextSessions] = useState<ContextBotSession[]>([])
   const [paletteOpen, setPaletteOpen] = useState(false)
   const [quickDispatchOpen, setQuickDispatchOpen] = useState(false)
@@ -113,6 +115,7 @@ export default function App() {
         if (parsed && names.includes(parsed.ws)) {
           setWorkspace(parsed.ws)
           if (parsed.type && parsed.id) {
+            setShowDoneWorkers(false)
             setSelected({ type: parsed.type, id: parsed.id })
           }
         } else {
@@ -126,6 +129,7 @@ export default function App() {
   }, [])
 
   const navigateTo = (type: EntityType, id: string) => {
+    setShowDoneWorkers(false)
     setSelected({ type, id })
     updateHash(workspace, type, id)
   }
@@ -355,9 +359,11 @@ export default function App() {
       if (!parsed) return
       if (parsed.ws) setWorkspace(parsed.ws)
       if (parsed.type && parsed.id) {
+        setShowDoneWorkers(false)
         setSelected({ type: parsed.type, id: parsed.id })
       } else {
         setSelected(null)
+        setShowDoneWorkers(false)
       }
     }
     window.addEventListener('hashchange', handleHashChange)
@@ -368,7 +374,6 @@ export default function App() {
   const activeWorkers = workers.filter((w) => !DONE_STATES.includes(w.state))
   const doneWorkers = workers.filter((w) => DONE_STATES.includes(w.state))
   const sidebarWorkers = activeWorkers.map(workerToSidebarItem)
-  const sidebarDoneWorkers = doneWorkers.map(workerToSidebarItem)
   const sidebarAutoBots = autoBots.map(autoBotToSidebarItem)
 
   const activityItems = workers
@@ -383,14 +388,15 @@ export default function App() {
       selectedType={selected?.type ?? null}
       selectedId={selected?.id ?? null}
       onSelect={handleSelect}
-      onHome={() => { setSelected(null); setMobileTab('dashboard'); updateHash(workspace) }}
+      onHome={() => { setSelected(null); setShowDoneWorkers(false); setMobileTab('dashboard'); updateHash(workspace) }}
       autoBots={sidebarAutoBots}
       workers={sidebarWorkers}
       doneWorkerCount={doneWorkers.length}
-      doneWorkers={sidebarDoneWorkers}
+      onShowDoneWorkers={() => { setSelected(null); setShowDoneWorkers(true); setMobileTab('dashboard') }}
+      doneWorkersSelected={showDoneWorkers}
       workspaces={workspaces}
       workspace={workspace}
-      onWorkspaceChange={(ws) => { setWorkspace(ws); setSelected(null); updateHash(ws) }}
+      onWorkspaceChange={(ws) => { setWorkspace(ws); setSelected(null); setShowDoneWorkers(false); updateHash(ws) }}
       onQuickDispatch={() => setQuickDispatchOpen(true)}
       activityItems={activityItems}
     />
@@ -416,6 +422,11 @@ export default function App() {
         onOpenContextBot={openContextBot}
       />
     )
+  ) : showDoneWorkers ? (
+    <CompletedWorkersView
+      workers={doneWorkers}
+      onSelectWorker={(id) => navigateTo('worker', id)}
+    />
   ) : (
     <Dashboard
       workspace={workspace}
@@ -434,7 +445,7 @@ export default function App() {
         <WorkerDetailV2
           workspace={workspace}
           workerId={selected.id}
-          onBack={() => { setSelected(null); updateHash(workspace) }}
+          onBack={() => { setSelected(null); setShowDoneWorkers(false); updateHash(workspace) }}
           onOpenContextBot={openContextBot}
           onNavigateToWorker={(id) => navigateTo('worker', id)}
         />
@@ -453,6 +464,14 @@ export default function App() {
     // No selection — show tab content
     if (mobileTab === 'workers') return mobileList
     if (mobileTab === 'auto_bots') return mobileList
+    if (showDoneWorkers) {
+      return (
+        <CompletedWorkersView
+          workers={doneWorkers}
+          onSelectWorker={(id) => navigateTo('worker', id)}
+        />
+      )
+    }
     return (
       <Dashboard
         workspace={workspace}
@@ -482,16 +501,18 @@ export default function App() {
             selectedType={selected?.type ?? null}
             selectedId={selected?.id ?? null}
             onSelect={handleSelect}
-            onHome={() => { setSelected(null); updateHash(workspace) }}
+            onHome={() => { setSelected(null); setShowDoneWorkers(false); updateHash(workspace) }}
             autoBots={sidebarAutoBots}
             workers={sidebarWorkers}
             doneWorkerCount={doneWorkers.length}
-            doneWorkers={sidebarDoneWorkers}
+            onShowDoneWorkers={() => { setSelected(null); setShowDoneWorkers(true) }}
+            doneWorkersSelected={showDoneWorkers}
             workspaces={workspaces}
             workspace={workspace}
             onWorkspaceChange={(ws) => {
               setWorkspace(ws)
               setSelected(null)
+              setShowDoneWorkers(false)
               updateHash(ws)
             }}
             onQuickDispatch={() => setQuickDispatchOpen(true)}
@@ -503,7 +524,7 @@ export default function App() {
           <BottomTabBar
             tabs={tabs}
             activeTab={mobileTab}
-            onTabChange={(id) => { setMobileTab(id); setSelected(null); updateHash(workspace) }}
+            onTabChange={(id) => { setMobileTab(id); setSelected(null); setShowDoneWorkers(false); updateHash(workspace) }}
           />
         }
       />

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -57,6 +57,28 @@ const mockWorkers: WorkerV2[] = [
     created_at: "2026-05-04T09:00:00Z",
     updated_at: "2026-05-04T10:00:00Z",
   },
+  {
+    id: "w-3",
+    workspace: "default",
+    state: "done",
+    label: "Done",
+    brief: null,
+    repo: "apiari",
+    branch: "swarm/ship-auth",
+    goal: "ship-auth-fix",
+    tests_passing: true,
+    branch_ready: true,
+    pr_url: "https://github.com/example/apiari/pull/44",
+    pr_approved: true,
+    is_stalled: false,
+    revision_count: 0,
+    review_mode: "local_first",
+    blocked_reason: null,
+    last_output_at: null,
+    state_entered_at: "2026-05-04T11:00:00Z",
+    created_at: "2026-05-04T09:30:00Z",
+    updated_at: "2026-05-04T11:00:00Z",
+  },
 ];
 
 const mockWorkerDetail: WorkerDetailV2Data = {
@@ -210,5 +232,14 @@ describe("App shell", () => {
   it("sidebar navigation has accessible label", () => {
     render(<App />);
     expect(screen.getByRole("navigation", { name: "Sidebar" })).toBeInTheDocument();
+  });
+
+  it("opens the completed workers view from the sidebar footer", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    const footer = await screen.findByTestId("done-workers-footer");
+    await user.click(footer);
+    expect(await screen.findByText("Completed workers", { selector: "h1" })).toBeInTheDocument();
+    expect(screen.getByText("ship-auth-fix")).toBeInTheDocument();
   });
 });

--- a/web/src/__tests__/Dashboard.test.tsx
+++ b/web/src/__tests__/Dashboard.test.tsx
@@ -76,6 +76,12 @@ describe("Dashboard", () => {
     expect(screen.getByText("No active workers")).toBeInTheDocument();
   });
 
+  it("renders 'No active workers' when only terminal workers exist", () => {
+    const workers = [makeWorker({ id: "w-done", state: "done", goal: "Finished task" })];
+    render(<Dashboard {...defaultProps} workers={workers} />);
+    expect(screen.getByText("No active workers")).toBeInTheDocument();
+  });
+
   it("renders Running stat pill when running workers exist", () => {
     const workers = [
       makeWorker({ id: "w-1", state: "running" }),
@@ -129,6 +135,26 @@ describe("Dashboard", () => {
     expect(screen.getByText("Stalled task")).toBeInTheDocument();
   });
 
+  it("shows recent completed workers in a history list", () => {
+    const workers = [
+      makeWorker({ id: "w-1", state: "done", goal: "First done", updated_at: "2026-05-04T09:00:00Z" }),
+      makeWorker({ id: "w-2", state: "done", goal: "Latest done", updated_at: "2026-05-04T10:00:00Z" }),
+    ];
+    render(<Dashboard {...defaultProps} workers={workers} />);
+    expect(screen.getByText("Recent workers")).toBeInTheDocument();
+    expect(screen.getAllByText("Completed")).toHaveLength(2);
+    const rows = screen.getAllByRole("button");
+    const latestRow = rows.find((row) => row.textContent?.includes("Latest done"));
+    expect(latestRow?.textContent).toContain("Completed");
+  });
+
+  it("shows abandoned workers in the recent history list", () => {
+    const workers = [makeWorker({ id: "w-1", state: "abandoned", goal: "Closed task" })];
+    render(<Dashboard {...defaultProps} workers={workers} />);
+    expect(screen.getByText("Recent workers")).toBeInTheDocument();
+    expect(screen.getByText("Abandoned")).toBeInTheDocument();
+  });
+
   it("calls onSelectWorker when attention row is clicked", () => {
     const onSelectWorker = vi.fn();
     const workers = [makeWorker({ id: "w-42", state: "waiting", goal: "Fix bug" })];
@@ -141,6 +167,20 @@ describe("Dashboard", () => {
     );
     fireEvent.click(screen.getByText("Fix bug").closest("button")!);
     expect(onSelectWorker).toHaveBeenCalledWith("w-42");
+  });
+
+  it("calls onSelectWorker when recent worker row is clicked", () => {
+    const onSelectWorker = vi.fn();
+    const workers = [makeWorker({ id: "w-84", state: "done", goal: "Shipped task" })];
+    render(
+      <Dashboard
+        {...defaultProps}
+        workers={workers}
+        onSelectWorker={onSelectWorker}
+      />,
+    );
+    fireEvent.click(screen.getByText("Shipped task").closest("button")!);
+    expect(onSelectWorker).toHaveBeenCalledWith("w-84");
   });
 
   it("does not show attention list when all workers are running", () => {

--- a/web/src/__tests__/Sidebar.test.tsx
+++ b/web/src/__tests__/Sidebar.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import Sidebar from "../components/Sidebar/Sidebar";
 import type { SidebarItem } from "../components/Sidebar/Sidebar";
@@ -18,11 +17,6 @@ const defaultProps = {
 const workerItems: SidebarItem[] = [
   { id: "w-1", name: "Fix auth", status: "running" },
   { id: "w-2", name: "Update deps", status: "waiting" },
-];
-
-const doneWorkerItems: SidebarItem[] = [
-  { id: "w-9", name: "Ship auth fix", status: "done" },
-  { id: "w-10", name: "Close stale worker", status: "done" },
 ];
 
 const botItems: SidebarItem[] = [
@@ -75,35 +69,17 @@ describe("Sidebar done workers filtering", () => {
     expect(footer).toHaveTextContent("3 completed");
   });
 
-  it("expands completed workers when the footer is clicked", async () => {
-    const user = userEvent.setup();
+  it("calls onShowDoneWorkers when the footer is clicked", () => {
+    const onShowDoneWorkers = vi.fn();
     render(
       <Sidebar
         {...defaultProps}
         doneWorkerCount={2}
-        doneWorkers={doneWorkerItems}
+        onShowDoneWorkers={onShowDoneWorkers}
       />,
     );
-    await user.click(screen.getByTestId("done-workers-footer"));
-    expect(screen.getByTestId("done-workers-list")).toBeInTheDocument();
-    expect(screen.getByText("Ship auth fix")).toBeInTheDocument();
-    expect(screen.getByText("Close stale worker")).toBeInTheDocument();
-  });
-
-  it("calls onSelect when a completed worker is chosen from the expanded list", async () => {
-    const user = userEvent.setup();
-    const onSelect = vi.fn();
-    render(
-      <Sidebar
-        {...defaultProps}
-        onSelect={onSelect}
-        doneWorkerCount={1}
-        doneWorkers={[doneWorkerItems[0]]}
-      />,
-    );
-    await user.click(screen.getByTestId("done-workers-footer"));
-    await user.click(screen.getByText("Ship auth fix"));
-    expect(onSelect).toHaveBeenCalledWith("worker", "w-9");
+    screen.getByTestId("done-workers-footer").click();
+    expect(onShowDoneWorkers).toHaveBeenCalled();
   });
 
   it("shows 'No workers yet' when workers is empty and doneWorkerCount is 0", () => {

--- a/web/src/__tests__/Sidebar.test.tsx
+++ b/web/src/__tests__/Sidebar.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import Sidebar from "../components/Sidebar/Sidebar";
 import type { SidebarItem } from "../components/Sidebar/Sidebar";
@@ -17,6 +18,11 @@ const defaultProps = {
 const workerItems: SidebarItem[] = [
   { id: "w-1", name: "Fix auth", status: "running" },
   { id: "w-2", name: "Update deps", status: "waiting" },
+];
+
+const doneWorkerItems: SidebarItem[] = [
+  { id: "w-9", name: "Ship auth fix", status: "done" },
+  { id: "w-10", name: "Close stale worker", status: "done" },
 ];
 
 const botItems: SidebarItem[] = [
@@ -67,6 +73,37 @@ describe("Sidebar done workers filtering", () => {
     const footer = screen.getByTestId("done-workers-footer");
     expect(footer).toBeInTheDocument();
     expect(footer).toHaveTextContent("3 completed");
+  });
+
+  it("expands completed workers when the footer is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <Sidebar
+        {...defaultProps}
+        doneWorkerCount={2}
+        doneWorkers={doneWorkerItems}
+      />,
+    );
+    await user.click(screen.getByTestId("done-workers-footer"));
+    expect(screen.getByTestId("done-workers-list")).toBeInTheDocument();
+    expect(screen.getByText("Ship auth fix")).toBeInTheDocument();
+    expect(screen.getByText("Close stale worker")).toBeInTheDocument();
+  });
+
+  it("calls onSelect when a completed worker is chosen from the expanded list", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <Sidebar
+        {...defaultProps}
+        onSelect={onSelect}
+        doneWorkerCount={1}
+        doneWorkers={[doneWorkerItems[0]]}
+      />,
+    );
+    await user.click(screen.getByTestId("done-workers-footer"));
+    await user.click(screen.getByText("Ship auth fix"));
+    expect(onSelect).toHaveBeenCalledWith("worker", "w-9");
   });
 
   it("shows 'No workers yet' when workers is empty and doneWorkerCount is 0", () => {

--- a/web/src/components/CompletedWorkersView.module.css
+++ b/web/src/components/CompletedWorkersView.module.css
@@ -1,0 +1,131 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+  padding: var(--space-7) var(--space-7) var(--space-8);
+  background: var(--bg);
+  gap: var(--space-6);
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.eyebrow {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.title {
+  margin: 0;
+  font-size: 30px;
+  line-height: 1;
+  color: var(--text-strong);
+}
+
+.summary {
+  margin: 0;
+  max-width: 60ch;
+  color: var(--text-faint);
+  line-height: 1.5;
+}
+
+.empty {
+  color: var(--text-faint);
+  font-size: 14px;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.row {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-4);
+  width: 100%;
+  padding: 16px 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-card);
+  text-align: left;
+  cursor: pointer;
+  font-family: var(--font);
+  transition: background 120ms, border-color 120ms;
+}
+
+.row:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+}
+
+.rowMain {
+  min-width: 0;
+}
+
+.rowTitle {
+  color: var(--text-strong);
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.rowMeta {
+  margin-top: 4px;
+  color: var(--text-faint);
+  font-size: 12px;
+  font-family: var(--font-mono);
+}
+
+.rowSide {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.status,
+.metaPill {
+  font-size: 11px;
+  line-height: 1;
+  padding: 6px 8px;
+  border-radius: 999px;
+}
+
+.statusDone {
+  color: var(--status-merged);
+  background: color-mix(in srgb, var(--status-merged) 18%, transparent);
+}
+
+.statusAbandoned {
+  color: #bcbcbc;
+  background: color-mix(in srgb, var(--status-abandoned) 24%, transparent);
+}
+
+.metaPill {
+  color: var(--text-faint);
+  background: var(--bg-hover);
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: var(--space-4) var(--space-4) var(--space-6);
+    padding-bottom: calc(var(--bottom-bar-height) + var(--space-4));
+  }
+
+  .row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .rowSide {
+    flex-wrap: wrap;
+  }
+}

--- a/web/src/components/CompletedWorkersView.tsx
+++ b/web/src/components/CompletedWorkersView.tsx
@@ -1,0 +1,63 @@
+import type { WorkerV2 } from "../types";
+import styles from "./CompletedWorkersView.module.css";
+
+interface Props {
+  workers: WorkerV2[];
+  onSelectWorker: (id: string) => void;
+}
+
+function statusLabel(state: WorkerV2["state"]): string {
+  return state === "abandoned" ? "Abandoned" : "Completed";
+}
+
+function workerTitle(worker: WorkerV2): string {
+  return worker.goal ?? worker.branch ?? worker.id;
+}
+
+export default function CompletedWorkersView({ workers, onSelectWorker }: Props) {
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <span className={styles.eyebrow}>Worker history</span>
+        <h1 className={styles.title}>Completed workers</h1>
+        <p className={styles.summary}>
+          Closed worker history across this workspace. Open any row to inspect its detail view.
+        </p>
+      </div>
+
+      {workers.length === 0 ? (
+        <div className={styles.empty}>No completed or abandoned workers yet.</div>
+      ) : (
+        <div className={styles.list}>
+          {workers.map((worker) => (
+            <button
+              key={worker.id}
+              type="button"
+              className={styles.row}
+              onClick={() => onSelectWorker(worker.id)}
+            >
+              <div className={styles.rowMain}>
+                <div className={styles.rowTitle}>{workerTitle(worker)}</div>
+                <div className={styles.rowMeta}>{worker.id}</div>
+              </div>
+              <div className={styles.rowSide}>
+                <span
+                  className={`${styles.status} ${
+                    worker.state === "abandoned" ? styles.statusAbandoned : styles.statusDone
+                  }`}
+                >
+                  {statusLabel(worker.state)}
+                </span>
+                {worker.pr_url ? (
+                  <span className={styles.metaPill}>PR linked</span>
+                ) : worker.branch_ready ? (
+                  <span className={styles.metaPill}>Branch ready</span>
+                ) : null}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/Dashboard/Dashboard.module.css
+++ b/web/src/components/Dashboard/Dashboard.module.css
@@ -146,6 +146,24 @@
   flex-shrink: 0;
 }
 
+.historyState {
+  font-size: 11px;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 3px 8px;
+  flex-shrink: 0;
+}
+
+.historyStateDone {
+  background: color-mix(in srgb, var(--status-merged) 18%, transparent);
+  color: var(--status-merged);
+}
+
+.historyStateAbandoned {
+  background: color-mix(in srgb, var(--status-abandoned) 22%, transparent);
+  color: #b4b4b4;
+}
+
 /* ── Widget grid ─────────────────────────────────────────────────────────── */
 
 .widgetGrid {

--- a/web/src/components/Dashboard/Dashboard.tsx
+++ b/web/src/components/Dashboard/Dashboard.tsx
@@ -8,10 +8,36 @@ import styles from './Dashboard.module.css'
 
 // ── Worker summary (built-in stat_row widget) ──────────────────────────────
 
+function formatWorkerStatus(state: WorkerV2['state']): string {
+  switch (state) {
+    case 'done':
+      return 'Completed'
+    case 'abandoned':
+      return 'Abandoned'
+    case 'waiting':
+      return 'Waiting'
+    case 'stalled':
+      return 'Stalled'
+    case 'running':
+      return 'Running'
+    default:
+      return state
+  }
+}
+
+function sortNewestFirst(a: WorkerV2, b: WorkerV2): number {
+  return b.updated_at.localeCompare(a.updated_at)
+}
+
 function WorkerSummary({ workers, onSelectWorker }: { workers: WorkerV2[]; onSelectWorker: (id: string) => void }) {
-  const running = workers.filter((w) => w.state === 'running')
-  const waiting = workers.filter((w) => w.state === 'waiting')
-  const stalled = workers.filter((w) => w.state === 'stalled')
+  const activeWorkers = workers.filter((w) => w.state !== 'done' && w.state !== 'abandoned')
+  const recentWorkers = workers
+    .filter((w) => w.state === 'done' || w.state === 'abandoned')
+    .slice()
+    .sort(sortNewestFirst)
+  const running = activeWorkers.filter((w) => w.state === 'running')
+  const waiting = activeWorkers.filter((w) => w.state === 'waiting')
+  const stalled = activeWorkers.filter((w) => w.state === 'stalled')
 
   const attentionWorkers = [...stalled, ...waiting]
 
@@ -29,7 +55,7 @@ function WorkerSummary({ workers, onSelectWorker }: { workers: WorkerV2[]; onSel
             <span className={styles.statPillLabel}>{s.label}</span>
           </div>
         ))}
-        {workers.length === 0 && <span className={styles.emptyMsg}>No active workers</span>}
+        {activeWorkers.length === 0 && <span className={styles.emptyMsg}>No active workers</span>}
       </div>
 
       {/* Attention list */}
@@ -48,6 +74,26 @@ function WorkerSummary({ workers, onSelectWorker }: { workers: WorkerV2[]; onSel
               </button>
             )
           })}
+        </div>
+      )}
+
+      {recentWorkers.length > 0 && (
+        <div className={styles.attentionList}>
+          <span className={styles.attentionHeading}>Recent workers</span>
+          {recentWorkers.slice(0, 8).map((w) => (
+            <button key={w.id} className={styles.attentionRow} onClick={() => onSelectWorker(w.id)}>
+              <span
+                className={styles.attentionDot}
+                style={{ background: w.state === 'abandoned' ? 'var(--status-abandoned)' : 'var(--status-merged)' }}
+              />
+              <span className={styles.attentionName}>{getWorkerTitle(w)}</span>
+              <span
+                className={`${styles.historyState} ${w.state === 'abandoned' ? styles.historyStateAbandoned : styles.historyStateDone}`}
+              >
+                {formatWorkerStatus(w.state)}
+              </span>
+            </button>
+          ))}
         </div>
       )}
     </div>

--- a/web/src/components/Sidebar/Sidebar.module.css
+++ b/web/src/components/Sidebar/Sidebar.module.css
@@ -326,10 +326,9 @@
   opacity: 0.9;
 }
 
-.doneList {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+.doneFooterSelected {
+  color: var(--accent);
+  opacity: 1;
 }
 
 /* ── Activity strip ──────────────────────────────────────────────────────── */

--- a/web/src/components/Sidebar/Sidebar.module.css
+++ b/web/src/components/Sidebar/Sidebar.module.css
@@ -309,11 +309,27 @@
 }
 
 .doneFooter {
+  display: block;
+  width: 100%;
   padding: 4px 12px 8px;
   font-size: 11px;
   color: var(--text-faint);
   font-family: var(--font);
   opacity: 0.6;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.doneFooter:hover {
+  opacity: 0.9;
+}
+
+.doneList {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
 }
 
 /* ── Activity strip ──────────────────────────────────────────────────────── */

--- a/web/src/components/Sidebar/Sidebar.tsx
+++ b/web/src/components/Sidebar/Sidebar.tsx
@@ -33,8 +33,8 @@ export interface SidebarProps {
   onQuickDispatch?: () => void
   /** Number of workers hidden because they are in a terminal state (merged/abandoned/failed). */
   doneWorkerCount?: number
-  /** Terminal workers that can be expanded from the completed footer. */
-  doneWorkers?: SidebarItem[]
+  onShowDoneWorkers?: () => void
+  doneWorkersSelected?: boolean
   /** Running background activity items shown at the bottom of the sidebar. */
   activityItems?: ActivityItem[]
 }
@@ -162,10 +162,10 @@ export default function Sidebar({
   onWorkspaceChange,
   onQuickDispatch,
   doneWorkerCount = 0,
-  doneWorkers = [],
+  onShowDoneWorkers,
+  doneWorkersSelected = false,
   activityItems,
 }: SidebarProps) {
-  const [doneOpen, setDoneOpen] = useState(false)
   const homeSelected = selectedType === null && selectedId === null
   return (
     <nav className={styles.sidebar} aria-label="Sidebar">
@@ -234,27 +234,12 @@ export default function Sidebar({
         {doneWorkerCount > 0 && (
           <button
             type="button"
-            className={styles.doneFooter}
+            className={`${styles.doneFooter} ${doneWorkersSelected ? styles.doneFooterSelected : ''}`}
             data-testid="done-workers-footer"
-            onClick={() => setDoneOpen((open) => !open)}
-            aria-expanded={doneOpen}
-            aria-controls="done-workers-list"
+            onClick={onShowDoneWorkers}
           >
             {doneWorkerCount} completed
           </button>
-        )}
-        {doneOpen && doneWorkers.length > 0 && (
-          <div id="done-workers-list" className={styles.doneList} data-testid="done-workers-list">
-            {doneWorkers.map((worker) => (
-              <SidebarItemRow
-                key={worker.id}
-                item={worker}
-                type="worker"
-                isSelected={selectedType === 'worker' && selectedId === worker.id}
-                onSelect={onSelect}
-              />
-            ))}
-          </div>
         )}
       </div>
       {activityItems && activityItems.length > 0 && (

--- a/web/src/components/Sidebar/Sidebar.tsx
+++ b/web/src/components/Sidebar/Sidebar.tsx
@@ -33,6 +33,8 @@ export interface SidebarProps {
   onQuickDispatch?: () => void
   /** Number of workers hidden because they are in a terminal state (merged/abandoned/failed). */
   doneWorkerCount?: number
+  /** Terminal workers that can be expanded from the completed footer. */
+  doneWorkers?: SidebarItem[]
   /** Running background activity items shown at the bottom of the sidebar. */
   activityItems?: ActivityItem[]
 }
@@ -160,8 +162,10 @@ export default function Sidebar({
   onWorkspaceChange,
   onQuickDispatch,
   doneWorkerCount = 0,
+  doneWorkers = [],
   activityItems,
 }: SidebarProps) {
+  const [doneOpen, setDoneOpen] = useState(false)
   const homeSelected = selectedType === null && selectedId === null
   return (
     <nav className={styles.sidebar} aria-label="Sidebar">
@@ -228,9 +232,29 @@ export default function Sidebar({
           ))
         )}
         {doneWorkerCount > 0 && (
-          <p className={styles.doneFooter} data-testid="done-workers-footer">
+          <button
+            type="button"
+            className={styles.doneFooter}
+            data-testid="done-workers-footer"
+            onClick={() => setDoneOpen((open) => !open)}
+            aria-expanded={doneOpen}
+            aria-controls="done-workers-list"
+          >
             {doneWorkerCount} completed
-          </p>
+          </button>
+        )}
+        {doneOpen && doneWorkers.length > 0 && (
+          <div id="done-workers-list" className={styles.doneList} data-testid="done-workers-list">
+            {doneWorkers.map((worker) => (
+              <SidebarItemRow
+                key={worker.id}
+                item={worker}
+                type="worker"
+                isSelected={selectedType === 'worker' && selectedId === worker.id}
+                onSelect={onSelect}
+              />
+            ))}
+          </div>
         )}
       </div>
       {activityItems && activityItems.length > 0 && (


### PR DESCRIPTION
## Summary
- add recent terminal worker history to the dashboard overview
- keep active worker stats and attention rows focused on non-terminal workers
- add dashboard tests for completed and abandoned worker history

## Verification
- npx tsc --noEmit
- npx vitest run src/__tests__/Dashboard.test.tsx src/__tests__/App.test.tsx