### PR TITLE
fix: use worker display titles in overview surfaces

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,7 @@ import { Bot, Wrench, LayoutDashboard } from 'lucide-react'
 import { getWorkspaces, listWorkersV2, listAutoBots, connectWebSocket, chatWithContextBot } from './api'
 import type { WorkerV2, AutoBot, ContextBotContext, ContextBotSession } from './types'
 import type { SidebarItem } from './components/Sidebar/Sidebar'
+import { getWorkerTitle } from './utils/workerTitle'
 import './theme.css'
 
 let _nextSessionId = 0
@@ -60,13 +61,13 @@ function parseHash(hash: string): { ws: string; type?: EntityType; id?: string }
 }
 
 function workerToSidebarItem(w: WorkerV2): SidebarItem {
-  const goal = w.goal ?? w.branch ?? w.id
-  const shortGoal = goal.length > 40 ? goal.slice(0, 40).replace(/\s+\S*$/, '') + '…' : goal
+  const title = getWorkerTitle(w)
+  const shortTitle = title.length > 40 ? title.slice(0, 40).replace(/\s+\S*$/, '') + '…' : title
   const tags: SidebarItem['tags'] = []
   if (w.pr_url) tags.push({ label: 'PR', color: w.pr_approved ? 'green' : 'amber' })
   return {
     id: w.id,
-    name: shortGoal,
+    name: shortTitle,
     status: w.state,
     meta: w.id,
     tags,
@@ -372,7 +373,7 @@ export default function App() {
   const activityItems = workers
     .filter((w) => w.state === 'running')
     .map((w) => ({
-      label: `${(w.goal ?? w.id).slice(0, 35)} · running`,
+      label: `${getWorkerTitle(w).slice(0, 35)} · running`,
       color: 'var(--status-running)',
     }))
 

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -20,6 +20,7 @@ const mockWorkers: WorkerV2[] = [
     repo: "apiari",
     branch: "swarm/fix-auth",
     goal: "fix-auth-rate-limit",
+    display_title: "Fix auth rate limiting",
     tests_passing: true,
     branch_ready: false,
     pr_url: null,
@@ -42,6 +43,7 @@ const mockWorkers: WorkerV2[] = [
     repo: "apiari",
     branch: "swarm/update-deps",
     goal: "update-deps",
+    display_title: "Update dependencies",
     tests_passing: false,
     branch_ready: false,
     pr_url: null,
@@ -131,8 +133,8 @@ describe("App shell", () => {
   it("renders workers from API in the sidebar", async () => {
     render(<App />);
     // Names appear in both sidebar and dashboard, so use findAllByText
-    expect((await screen.findAllByText("fix-auth-rate-limit")).length).toBeGreaterThan(0);
-    expect((await screen.findAllByText("update-deps")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Fix auth rate limiting")).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText("Update dependencies")).length).toBeGreaterThan(0);
   });
 
   it("shows empty state when nothing is selected", async () => {
@@ -149,12 +151,12 @@ describe("App shell", () => {
     render(<App />);
     // Wait for sidebar to load then click the sidebar worker button
     const sidebarNav = await screen.findByRole("navigation", { name: "Sidebar" });
-    await screen.findAllByText("fix-auth-rate-limit");
+    await screen.findAllByText("Fix auth rate limiting");
     // Get all buttons with that name and click the first (sidebar) one
-    const workerBtns = screen.getAllByRole("button", { name: /fix-auth-rate-limit/ });
+    const workerBtns = screen.getAllByRole("button", { name: /Fix auth rate limiting/ });
     await user.click(workerBtns[0]);
-    // WorkerDetailV2 renders the goal as heading
-    expect(await screen.findByText("fix-auth-rate-limit", { selector: "h1" })).toBeInTheDocument();
+    // WorkerDetailV2 renders the display title as heading
+    expect(await screen.findByText("Fix auth rate limiting", { selector: "h1" })).toBeInTheDocument();
     expect(screen.queryByText("Select something")).not.toBeInTheDocument();
     // Keep sidebarNav reference to suppress unused warning
     expect(sidebarNav).toBeInTheDocument();
@@ -185,16 +187,16 @@ describe("App shell", () => {
     }));
     render(<App />);
     // Wait for sidebar buttons
-    await screen.findAllByText("fix-auth-rate-limit");
-    const workerBtns = screen.getAllByRole("button", { name: /fix-auth-rate-limit/ });
+    await screen.findAllByText("Fix auth rate limiting");
+    const workerBtns = screen.getAllByRole("button", { name: /Fix auth rate limiting/ });
     await user.click(workerBtns[0]);
-    expect(await screen.findByText("fix-auth-rate-limit", { selector: "h1" })).toBeInTheDocument();
-    const updateDepsBtns = screen.getAllByRole("button", { name: /update-deps/ });
+    expect(await screen.findByText("Fix auth rate limiting", { selector: "h1" })).toBeInTheDocument();
+    const updateDepsBtns = screen.getAllByRole("button", { name: /Update dependencies/ });
     await user.click(updateDepsBtns[0]);
     await waitFor(() => {
-      expect(screen.queryByText("fix-auth-rate-limit", { selector: "h1" })).not.toBeInTheDocument();
+      expect(screen.queryByText("Fix auth rate limiting", { selector: "h1" })).not.toBeInTheDocument();
     });
-    expect(await screen.findByText("update-deps", { selector: "h1" })).toBeInTheDocument();
+    expect(await screen.findByText("Update dependencies", { selector: "h1" })).toBeInTheDocument();
   });
 
   it("renders the mobile bottom tab bar with Auto Bots and Workers tabs", () => {

--- a/web/src/__tests__/CommandPaletteV2.test.tsx
+++ b/web/src/__tests__/CommandPaletteV2.test.tsx
@@ -54,8 +54,8 @@ function makeAutoBot(overrides: Partial<AutoBot> = {}): AutoBot {
 }
 
 const workers = [
-  makeWorker({ id: "w-1", goal: "Fix auth rate limiting", branch: "swarm/fix-auth" }),
-  makeWorker({ id: "w-2", goal: "Update deps", branch: "swarm/update-deps", state: "waiting", label: "Waiting" }),
+  makeWorker({ id: "w-1", goal: "worker prompt text", display_title: "Fix auth rate limiting", branch: "swarm/fix-auth" }),
+  makeWorker({ id: "w-2", goal: "secondary prompt", display_title: "Update deps", branch: "swarm/update-deps", state: "waiting", label: "Waiting" }),
 ];
 
 const autoBots = [
@@ -83,6 +83,7 @@ describe("CommandPalette", () => {
     render(<CommandPalette {...defaultProps} />);
     expect(screen.getByText("Fix auth rate limiting")).toBeInTheDocument();
     expect(screen.getByText("Update deps")).toBeInTheDocument();
+    expect(screen.queryByText("worker prompt text")).not.toBeInTheDocument();
   });
 
   it("renders auto bot rows", () => {
@@ -98,6 +99,14 @@ describe("CommandPalette", () => {
     await user.type(input, "auth");
     expect(screen.getByText("Fix auth rate limiting")).toBeInTheDocument();
     expect(screen.queryByText("Update deps")).not.toBeInTheDocument();
+  });
+
+  it("matches workers by display title", async () => {
+    const user = userEvent.setup();
+    render(<CommandPalette {...defaultProps} />);
+    const input = screen.getByTestId("command-palette-input");
+    await user.type(input, "secondary");
+    expect(screen.getByText("Update deps")).toBeInTheDocument();
   });
 
   it("filters auto bots by query", async () => {

--- a/web/src/__tests__/CommandPaletteV2.test.tsx
+++ b/web/src/__tests__/CommandPaletteV2.test.tsx
@@ -55,7 +55,7 @@ function makeAutoBot(overrides: Partial<AutoBot> = {}): AutoBot {
 
 const workers = [
   makeWorker({ id: "w-1", goal: "worker prompt text", display_title: "Fix auth rate limiting", branch: "swarm/fix-auth" }),
-  makeWorker({ id: "w-2", goal: "secondary prompt", display_title: "Update deps", branch: "swarm/update-deps", state: "waiting", label: "Waiting" }),
+  makeWorker({ id: "w-2", goal: "generic prompt", display_title: "Dependency refresh", branch: "swarm/update-deps", state: "waiting", label: "Waiting" }),
 ];
 
 const autoBots = [
@@ -82,7 +82,7 @@ describe("CommandPalette", () => {
   it("renders worker rows", () => {
     render(<CommandPalette {...defaultProps} />);
     expect(screen.getByText("Fix auth rate limiting")).toBeInTheDocument();
-    expect(screen.getByText("Update deps")).toBeInTheDocument();
+    expect(screen.getByText("Dependency refresh")).toBeInTheDocument();
     expect(screen.queryByText("worker prompt text")).not.toBeInTheDocument();
   });
 
@@ -98,15 +98,15 @@ describe("CommandPalette", () => {
     const input = screen.getByTestId("command-palette-input");
     await user.type(input, "auth");
     expect(screen.getByText("Fix auth rate limiting")).toBeInTheDocument();
-    expect(screen.queryByText("Update deps")).not.toBeInTheDocument();
+    expect(screen.queryByText("Dependency refresh")).not.toBeInTheDocument();
   });
 
   it("matches workers by display title", async () => {
     const user = userEvent.setup();
     render(<CommandPalette {...defaultProps} />);
     const input = screen.getByTestId("command-palette-input");
-    await user.type(input, "secondary");
-    expect(screen.getByText("Update deps")).toBeInTheDocument();
+    await user.type(input, "refresh");
+    expect(screen.getByText("Dependency refresh")).toBeInTheDocument();
   });
 
   it("filters auto bots by query", async () => {

--- a/web/src/__tests__/Dashboard.test.tsx
+++ b/web/src/__tests__/Dashboard.test.tsx
@@ -115,10 +115,11 @@ describe("Dashboard", () => {
   });
 
   it("shows attention list for waiting workers", () => {
-    const workers = [makeWorker({ id: "w-1", state: "waiting", goal: "Fix bug" })];
+    const workers = [makeWorker({ id: "w-1", state: "waiting", goal: "worker prompt", display_title: "Fix bug" })];
     render(<Dashboard {...defaultProps} workers={workers} />);
     expect(screen.getByText("Needs attention")).toBeInTheDocument();
     expect(screen.getByText("Fix bug")).toBeInTheDocument();
+    expect(screen.queryByText("worker prompt")).not.toBeInTheDocument();
   });
 
   it("shows attention list for stalled workers", () => {

--- a/web/src/components/CommandPalette/CommandPalette.tsx
+++ b/web/src/components/CommandPalette/CommandPalette.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import type { WorkerV2, AutoBot } from '../../types'
+import { getWorkerTitle } from '../../utils/workerTitle'
 import styles from './CommandPalette.module.css'
 
 // ── Helpers ───────────────────────────────────────────────────────────────
@@ -63,7 +64,7 @@ export default function CommandPalette({
 
   // Build filtered results
   const filteredWorkers = workers.filter((w) =>
-    matches(query, w.goal, w.branch, w.id),
+    matches(query, w.display_title, w.goal, w.branch, w.id),
   )
   const filteredBots = autoBots.filter((b) =>
     matches(query, b.name),
@@ -175,7 +176,7 @@ export default function CommandPalette({
                 const globalIdx = workerSectionStart + i
                 const isActive = globalIdx === activeIndex
                 const dotCls = workerDotClass(w.state)
-                const name = w.goal ?? w.branch ?? w.id
+                const name = getWorkerTitle(w)
 
                 return (
                   <button

--- a/web/src/components/Dashboard/Dashboard.tsx
+++ b/web/src/components/Dashboard/Dashboard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from 'react'
 import { LayoutDashboard } from 'lucide-react'
 import type { WorkerV2, AutoBot, DashboardWidget } from '../../types'
 import { listWidgets } from '../../api'
+import { getWorkerTitle } from '../../utils/workerTitle'
 import Widget from '../widgets/Widget'
 import styles from './Dashboard.module.css'
 
@@ -42,7 +43,7 @@ function WorkerSummary({ workers, onSelectWorker }: { workers: WorkerV2[]; onSel
             return (
               <button key={w.id} className={styles.attentionRow} onClick={() => onSelectWorker(w.id)}>
                 <span className={styles.attentionDot} style={{ background: dotColor }} />
-                <span className={styles.attentionName}>{w.goal ?? w.branch ?? w.id}</span>
+                <span className={styles.attentionName}>{getWorkerTitle(w)}</span>
                 <span className={styles.attentionId}>{w.id}</span>
               </button>
             )

--- a/web/src/utils/workerTitle.ts
+++ b/web/src/utils/workerTitle.ts
@@ -1,0 +1,5 @@
+import type { WorkerV2 } from "../types";
+
+export function getWorkerTitle(worker: Pick<WorkerV2, "display_title" | "goal" | "branch" | "id">): string {
+  return worker.display_title ?? worker.goal ?? worker.branch ?? worker.id;
+}

--- a/web/src/utils/workerTitle.ts
+++ b/web/src/utils/workerTitle.ts
@@ -1,5 +1,5 @@
-import type { WorkerV2 } from "../types";
+import type { WorkerV2 } from '../types'
 
-export function getWorkerTitle(worker: Pick<WorkerV2, "display_title" | "goal" | "branch" | "id">): string {
-  return worker.display_title ?? worker.goal ?? worker.branch ?? worker.id;
+export function getWorkerTitle(worker: Pick<WorkerV2, 'display_title' | 'goal' | 'branch' | 'id'>): string {
+  return worker.display_title ?? worker.goal ?? worker.branch ?? worker.id
 }


### PR DESCRIPTION
## Summary
- use worker display titles in sidebar, command palette, dashboard attention list, and running activity labels
- add a shared worker title helper so list surfaces match the worker detail header
- add targeted tests covering display-title behavior

## Verification
- npx vitest run src/__tests__/App.test.tsx src/__tests__/CommandPaletteV2.test.tsx src/__tests__/Dashboard.test.tsx
- npm run build *(fails on pre-existing TypeScript issues outside this change)*