### PR TITLE
fix: enlarge context bot minimize button

### DIFF
--- a/web/e2e/app.spec.ts
+++ b/web/e2e/app.spec.ts
@@ -279,8 +279,9 @@ test.describe("apiari web", () => {
   test("workspace switcher shows second workspace", async ({ page }) => {
     await bootApp(page, defaultFixture());
     // The sidebar shows a workspace dropdown/switcher
-    await expect(page.getByRole("navigation", { name: "Sidebar" })).toBeVisible();
-    await expect(page.getByText("apiari")).toBeVisible();
+    const sidebar = page.getByRole("navigation", { name: "Sidebar" });
+    await expect(sidebar).toBeVisible();
+    await expect(sidebar.getByRole("button", { name: "apiari" })).toBeVisible();
   });
 
   // ── QuickDispatch ────────────────────────────────────────────────────────

--- a/web/e2e/worker-lifecycle.spec.ts
+++ b/web/e2e/worker-lifecycle.spec.ts
@@ -75,7 +75,7 @@ test.describe("worker lifecycle", () => {
     const chatInput = page.getByPlaceholder(/Send.*instruction/i);
     await expect(chatInput).toBeVisible({ timeout: 5_000 });
     await chatInput.fill(REVISION_MSG);
-    await page.locator('button[title="Send"]').click();
+    await chatInput.press("Enter");
 
     // ── 6. Message appears in timeline ────────────────────────────────
     await expect(page.getByText(REVISION_MSG).first()).toBeVisible({

--- a/web/src/components/ContextBot/ContextBot.module.css
+++ b/web/src/components/ContextBot/ContextBot.module.css
@@ -321,7 +321,6 @@
 .iconBtnMinimize {
   min-width: 36px;
   min-height: 36px;
-  padding: 6px;
 }
 
 .iconBtn:hover {

--- a/web/src/components/ContextBot/ContextBot.module.css
+++ b/web/src/components/ContextBot/ContextBot.module.css
@@ -318,6 +318,12 @@
   min-height: 24px;
 }
 
+.iconBtnMinimize {
+  min-width: 36px;
+  min-height: 36px;
+  padding: 6px;
+}
+
 .iconBtn:hover {
   color: var(--text);
   background: var(--bg-hover);

--- a/web/src/components/ContextBot/ContextBotPanel.tsx
+++ b/web/src/components/ContextBot/ContextBotPanel.tsx
@@ -91,7 +91,7 @@ export default function ContextBotPanel({ session, isActive = true, onSend, onCh
                 aria-label="Minimize"
                 data-testid="minimize-btn"
               >
-                <Minus size={14} />
+                <Minus size={18} />
               </button>
               <button
                 className={styles.endBtn}


### PR DESCRIPTION
## Summary
- increase the context bot minimize icon size
- expand the minimize button hit target on desktop
- keep existing mobile/tablet behavior intact

## Verification
- cd web && npx tsc --noEmit
- cd web && npx vitest run