### PR TITLE
Fix context bot worker dispatch to match modal dispatch quality

### DIFF
--- a/crates/apiari/src/daemon/http.rs
+++ b/crates/apiari/src/daemon/http.rs
@@ -6322,25 +6322,130 @@ async fn v2_context_bot_chat(
         if let Some(goal) = trimmed.strip_prefix("DISPATCH_WORKER:") {
             let goal = goal.trim().to_string();
             if !goal.is_empty() {
-                let worker_id = format!("ctx-{}", uuid::Uuid::new_v4());
-                let prompt_path = std::env::temp_dir().join(format!("ctx-worker-{worker_id}.txt"));
-
                 // Determine repo from workspace config (use first configured repo if available).
                 let repo = ws
                     .as_ref()
                     .and_then(|w| w.config.repos.first())
-                    .map(String::as_str)
-                    .unwrap_or("");
+                    .cloned()
+                    .unwrap_or_default();
 
-                let brief = format!("Context bot dispatch:\n\n{goal}\n\nWorkspace: {workspace}");
-                let _ = tokio::fs::remove_file(&prompt_path).await;
-                if state
-                    .worker_manager
-                    .create_worker(&workspace_root, repo, &brief, "codex", None)
-                    .await
-                    .is_ok()
-                {
-                    dispatched_worker_id = Some(worker_id);
+                // Build a rich brief matching the modal dispatch path.
+                let context_value = serde_json::json!({
+                    "view": body.context.view,
+                    "entity_id": body.context.entity_id,
+                    "entity_snapshot": body.context.entity_snapshot,
+                });
+                let brief_json = serde_json::json!({
+                    "goal": goal,
+                    "context": context_value,
+                    "constraints": [],
+                    "acceptance_criteria": [],
+                    "review_mode": "local_first",
+                });
+                let prompt_content = format_brief_as_prompt(&brief_json);
+
+                // Save the Worker row to SQLite before dispatching.
+                let worker_id = uuid::Uuid::new_v4().to_string();
+                let now = chrono::Utc::now().to_rfc3339();
+                let selected_agent = ws
+                    .as_ref()
+                    .map(|w| w.config.swarm.default_agent.clone())
+                    .unwrap_or_else(|| "codex".to_string());
+                let worker = crate::buzz::worker::Worker {
+                    id: worker_id.clone(),
+                    workspace: workspace.clone(),
+                    state: crate::buzz::worker::WorkerState::Briefed,
+                    brief: Some(brief_json.clone()),
+                    repo: Some(repo.clone()),
+                    branch: None,
+                    goal: Some(goal.clone()),
+                    tests_passing: false,
+                    branch_ready: false,
+                    pr_url: None,
+                    pr_approved: false,
+                    ci_passing: None,
+                    is_stalled: false,
+                    revision_count: 0,
+                    review_mode: "local_first".to_string(),
+                    blocked_reason: None,
+                    last_output_at: None,
+                    state_entered_at: now.clone(),
+                    created_at: now.clone(),
+                    updated_at: now,
+                    display_title: None,
+                    worktree_path: None,
+                    isolation_mode: None,
+                    agent_kind: Some(selected_agent.clone()),
+                    model: None,
+                    repo_path: None,
+                    label: String::new(),
+                };
+
+                let store_result = open_worker_store_from_path(&state.db_path);
+                if let Ok(store) = store_result {
+                    let _ = store.upsert(&worker);
+
+                    let isolation = ws
+                        .as_ref()
+                        .map(|w| w.config.swarm.worker_isolation.clone())
+                        .unwrap_or_default();
+                    let swarm_result = state
+                        .worker_manager
+                        .create_worker_with_task_dir(
+                            &workspace_root,
+                            &repo,
+                            &prompt_content,
+                            &selected_agent,
+                            None,
+                            None,
+                            isolation,
+                        )
+                        .await;
+
+                    if let Ok(swarm_id) = swarm_result {
+                        let final_id = if !swarm_id.is_empty() && swarm_id != worker_id {
+                            let _ = store.rekey(&worker_id, &swarm_id);
+                            let mut rekeyed = worker.clone();
+                            rekeyed.id = swarm_id.clone();
+                            rekeyed.state = crate::buzz::worker::WorkerState::Queued;
+                            let _ = store.upsert(&rekeyed);
+                            swarm_id
+                        } else {
+                            let _ = store.transition(
+                                &workspace,
+                                &worker_id,
+                                crate::buzz::worker::WorkerState::Queued,
+                            );
+                            worker_id.clone()
+                        };
+
+                        let _ =
+                            state
+                                .updates_tx
+                                .send(crate::daemon::http::WsUpdate::WorkerV2State {
+                                    workspace: workspace.clone(),
+                                    worker_id: final_id.clone(),
+                                    state: "queued".to_string(),
+                                    label: "Queued".to_string(),
+                                    properties: serde_json::json!({}),
+                                });
+
+                        let title_workspace = workspace.clone();
+                        let title_goal = goal.clone();
+                        let title_id = final_id.clone();
+                        let db_path = state.db_path.clone();
+                        tokio::spawn(async move {
+                            generate_and_store_worker_title(
+                                &title_workspace,
+                                &title_id,
+                                &title_goal,
+                                &db_path,
+                            )
+                            .await;
+                        });
+
+                        dispatched_worker_id = Some(final_id);
+                    }
                 }
                 break;
             }

--- a/web/src/components/QuickDispatch/QuickDispatch.tsx
+++ b/web/src/components/QuickDispatch/QuickDispatch.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
-import { getRepos, createWorkerV2, chatWithContextBot } from '../../api'
+import { getRepos, createWorkerV2 } from '../../api'
 import type { Repo } from '../../types'
 import styles from './QuickDispatch.module.css'
 
@@ -113,19 +113,6 @@ export default function QuickDispatch({ workspace, onClose, onDispatched }: Quic
         },
         repo: selectedRepo,
         ...(agent !== 'auto' ? { agent, model } : {}),
-      })
-
-      // Fire-and-forget: enrich the brief with context bot in background
-      chatWithContextBot(
-        workspace,
-        'Generate a detailed implementation brief for: ' + intent.trim(),
-        {
-          view: 'quick_dispatch',
-          entity_id: null,
-          entity_snapshot: { goal: intent.trim(), repo: selectedRepo },
-        },
-      ).catch(() => {
-        // ignore — this is best-effort enrichment
       })
 
       onDispatched(worker.worker_id)

--- a/web/src/components/WorkerDetailV2/WorkerDetailV2.module.css
+++ b/web/src/components/WorkerDetailV2/WorkerDetailV2.module.css
@@ -965,6 +965,49 @@
   flex-shrink: 0;
 }
 
+.briefDisclosure {
+  margin-top: var(--space-2);
+}
+
+.briefDisclosureSummary {
+  font-size: var(--font-size-meta);
+  font-variant: small-caps;
+  letter-spacing: 0.08em;
+  color: var(--text-faint);
+  font-weight: 600;
+  text-transform: uppercase;
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+}
+
+.briefDisclosureSummary::-webkit-details-marker {
+  display: none;
+}
+
+.briefDisclosureSummary::before {
+  content: '▶ ';
+  font-size: 0.7em;
+  vertical-align: middle;
+}
+
+details[open] .briefDisclosureSummary::before {
+  content: '▼ ';
+}
+
+.briefDisclosurePre {
+  margin: var(--space-3) 0 0;
+  padding: var(--space-3);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 13px;
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+}
+
 /* ── Action bar (input) ──────────────────────────────────────────────────── */
 
 .actionBar {

--- a/web/src/components/WorkerDetailV2/WorkerDetailV2.tsx
+++ b/web/src/components/WorkerDetailV2/WorkerDetailV2.tsx
@@ -398,6 +398,21 @@ function ReviewCard({ review }: { review: WorkerReview }) {
 
 // ── Brief tab ────────────────────────────────────────────────────────────
 
+function formatBriefAsText(brief: WorkerBrief): string {
+  const parts: string[] = []
+  parts.push(`Goal\n${'─'.repeat(4)}\n${brief.goal ?? ''}`)
+  if (brief.context) {
+    parts.push(`Context\n${'─'.repeat(7)}\n${JSON.stringify(brief.context, null, 2)}`)
+  }
+  if (brief.constraints?.length) {
+    parts.push(`Constraints\n${'─'.repeat(11)}\n${brief.constraints.map(c => `- ${c}`).join('\n')}`)
+  }
+  if (brief.acceptance_criteria?.length) {
+    parts.push(`Acceptance Criteria\n${'─'.repeat(19)}\n${brief.acceptance_criteria.map(c => `- ${c}`).join('\n')}`)
+  }
+  return parts.join('\n\n')
+}
+
 function BriefSection({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className={styles.briefSection}>
@@ -621,6 +636,11 @@ function BriefTab({
               </ul>
             </BriefSection>
           )}
+
+          <details className={styles.briefDisclosure}>
+            <summary className={styles.briefDisclosureSummary}>Full prompt</summary>
+            <pre className={styles.briefDisclosurePre}>{formatBriefAsText(brief)}</pre>
+          </details>
         </>
       )}
 


### PR DESCRIPTION
## Summary

- **Rust**: Context bot `DISPATCH_WORKER:` handler now builds a structured brief JSON, saves a `Worker` row to SQLite (with `brief`, `goal`, `agent_kind`), uses `create_worker_with_task_dir` + `format_brief_as_prompt`, handles swarm ID rekeying, and spawns a title-generation task — matching the `v2_create_worker` pattern exactly
- **Frontend**: Added collapsible "Full prompt" `<details>` disclosure at the bottom of the Brief tab in `WorkerDetailV2`, reconstructing the prompt from brief fields (goal, context, constraints, acceptance criteria)
- **Frontend**: Removed the dead fire-and-forget `chatWithContextBot` enrichment call from `QuickDispatch` that discarded its result and wasted tokens

## Test plan
- [ ] `cargo clippy -p apiari -- -D warnings` passes (0 issues)
- [ ] `cargo test -p apiari` passes (1068/1069; pre-existing failure in `test_mocked_alt_provider_error_contracts_match` unrelated to this change)
- [ ] `npx tsc --noEmit` passes
- [ ] `npx vitest run` passes (268/268)
- [ ] Context bot dispatch creates worker with Brief tab showing Goal + Full prompt disclosure
- [ ] QuickDispatch no longer fires context bot after dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)