### PR TITLE
fix: show minimized chat strips to left of FAB on desktop/iPad

### DIFF
--- a/web/src/components/ContextBot/ContextBot.module.css
+++ b/web/src/components/ContextBot/ContextBot.module.css
@@ -1,3 +1,34 @@
+/* ── Minimized layout: [strips column] [FAB] side by side ────────────── */
+
+.managerMinimized {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 100;
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.minimalizedStrips {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  align-items: flex-end;
+}
+
+/* FAB sits inline in the fixed row — override its own fixed positioning */
+.managerMinimized .fabWrap {
+  position: static;
+}
+
+.managerMinimized .fab {
+  position: relative;
+  bottom: unset;
+  right: unset;
+}
+
 /* ── Manager (container for all panels) ─────────────────────────────── */
 
 .manager {
@@ -148,6 +179,23 @@
     padding: 16px;
     font-size: 15px;
     min-height: 52px;
+  }
+
+  /* On mobile: managerMinimized behaves like fabWrap — strips hidden, FAB only */
+  .managerMinimized {
+    bottom: calc(var(--bottom-bar-height) + env(safe-area-inset-bottom, 0px) + 84px);
+    right: unset;
+    left: 16px;
+    align-items: flex-start;
+  }
+
+  .managerMinimized .minimalizedStrips {
+    display: none;
+  }
+
+  .managerMinimized .fab {
+    width: 44px;
+    height: 44px;
   }
 }
 

--- a/web/src/components/ContextBot/ContextBotManager.tsx
+++ b/web/src/components/ContextBot/ContextBotManager.tsx
@@ -46,7 +46,7 @@ export default function ContextBotManager({
   }, [fabMenuOpen]);
 
   const effectiveActiveId = activeId ?? sessions[sessions.length - 1]?.id ?? null;
-  const allMinimized = sessions.length === 0 || sessions.every((s) => s.minimized);
+  const allMinimized = sessions.length > 0 && sessions.every((s) => s.minimized);
 
   const handleClose = (id: string) => {
     if (id === effectiveActiveId) {
@@ -118,9 +118,35 @@ export default function ContextBotManager({
     </div>
   );
 
-  // No open sessions — show FAB only (desktop: nothing; mobile: FAB)
-  if (allMinimized) {
+  // No sessions — show FAB only
+  if (sessions.length === 0) {
     return fab;
+  }
+
+  // All sessions minimized: horizontal [strips column][FAB] at bottom-right
+  if (allMinimized) {
+    return (
+      <div className={styles.managerMinimized} data-testid="context-bot-manager">
+        <div className={styles.minimalizedStrips}>
+          {sessions.map((session) => (
+            <ContextBotPanel
+              key={session.id}
+              session={session}
+              isActive={session.id === effectiveActiveId}
+              onSend={onSend}
+              onChangeModel={onChangeModel}
+              onMinimize={(id) => {
+                const next = sessions.find((s) => s.id !== id && !s.minimized);
+                if (next) setActiveId(next.id);
+                onMinimize(id);
+              }}
+              onClose={handleClose}
+            />
+          ))}
+        </div>
+        {fab}
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- Removes the `allMinimized` early-return that was discarding strip elements and showing only the FAB
- Adds a `managerMinimized` fixed horizontal container: strips column on the left, FAB on the right
- Mobile (<768px): strips are hidden via media query, FAB stays at existing bottom-left position — no mobile behavior change

## Test plan
- [ ] Minimize one or more chat sessions on desktop — strips appear to the left of the FAB at bottom-right
- [ ] Multiple minimized sessions stack vertically in a column to the left of the FAB
- [ ] Clicking a strip reopens that session
- [ ] On mobile, minimized sessions still show only the FAB at bottom-left (strips hidden)
- [ ] All 253 frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)