### PR TITLE
fix: prevent horizontal overflow on mobile dashboard

### DIFF
--- a/web/src/components/Dashboard/Dashboard.module.css
+++ b/web/src/components/Dashboard/Dashboard.module.css
@@ -5,6 +5,7 @@
   flex-direction: column;
   height: 100%;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: var(--space-7) var(--space-7) var(--space-8);
   background: var(--bg);
   gap: var(--space-6);
@@ -235,6 +236,19 @@
 
   .widgetGrid {
     grid-template-columns: 1fr;
+  }
+
+  .statPills {
+    gap: var(--space-2);
+  }
+
+  .statPill {
+    padding: var(--space-3) var(--space-3);
+    min-width: 72px;
+  }
+
+  .statPillNum {
+    font-size: 20px;
   }
 
   /* FAB handles chat on mobile — hide the Ask button */

--- a/web/src/components/OverviewPanel.module.css
+++ b/web/src/components/OverviewPanel.module.css
@@ -1,6 +1,7 @@
 .page {
   flex: 1;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
   padding: var(--space-7);
   background:
     radial-gradient(circle at top right, rgba(217, 168, 74, 0.05), transparent 24%),

--- a/web/src/components/widgets/Widget.module.css
+++ b/web/src/components/widgets/Widget.module.css
@@ -587,6 +587,10 @@ a.feedEvent:hover {
   overflow-y: auto;
 }
 
+.markdown pre {
+  overflow-x: auto;
+}
+
 .markdown p {
   margin-bottom: var(--space-2);
 }


### PR DESCRIPTION
## Summary

- Add `overflow-x: hidden` to the Dashboard `.container` and OverviewPanel `.page` to stop horizontal scrolling. The root cause: `overflow-y: auto` implicitly sets `overflow-x` to `auto` per CSS spec, so any overflowing child creates a horizontal scrollbar.
- Reduce stat pill font size (28→20px) and padding on mobile so the built-in worker stat row doesn't look oversized on small screens.
- Add `overflow-x: auto` to `.markdown pre` so wide code blocks in markdown widgets scroll within the widget instead of pushing the page wider.

## Test plan

- [ ] Open the dashboard on a phone-sized viewport (375px width) — no horizontal scrollbar
- [ ] Stat pills (Running / Waiting / Stalled counts) are visually smaller on mobile
- [ ] A markdown widget with a long code block scrolls horizontally inside the widget, not the page
- [ ] All 253 frontend tests pass
- [ ] Rust clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)