### PR TITLE
The dashboard overview stretches bigger than width of phone screen and causes horizontal scrolling. Don’t also looks extra big on mobile.

### DIFF
--- a/web/src/components/Dashboard/Dashboard.module.css
+++ b/web/src/components/Dashboard/Dashboard.module.css
@@ -4,7 +4,9 @@
   display: flex;
   flex-direction: column;
   height: 100%;
+  min-width: 0;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: var(--space-7) var(--space-7) var(--space-8);
   background: var(--bg);
   gap: var(--space-6);
@@ -66,6 +68,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
+  min-width: 0;
 }
 
 .statPills {
@@ -240,6 +243,19 @@
   /* FAB handles chat on mobile — hide the Ask button */
   .askBtn {
     display: none;
+  }
+
+  .statPills {
+    gap: var(--space-2);
+  }
+
+  .statPill {
+    padding: 10px 12px;
+    min-width: 72px;
+  }
+
+  .statPillNum {
+    font-size: 22px;
   }
 }
 

--- a/web/src/components/OverviewPanel.module.css
+++ b/web/src/components/OverviewPanel.module.css
@@ -1,6 +1,8 @@
 .page {
   flex: 1;
-  overflow: auto;
+  min-width: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
   padding: var(--space-7);
   background:
     radial-gradient(circle at top right, rgba(217, 168, 74, 0.05), transparent 24%),


### PR DESCRIPTION
Created by apiari orchestrator