### PR TITLE
The dashboard overview stretches bigger than width of phone screen and causes horizontal scrolling. Don’t also looks extra big on mobile.

### DIFF
--- a/web/src/components/Dashboard/Dashboard.module.css
+++ b/web/src/components/Dashboard/Dashboard.module.css
@@ -5,6 +5,7 @@
   flex-direction: column;
   height: 100%;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: var(--space-7) var(--space-7) var(--space-8);
   background: var(--bg);
   gap: var(--space-6);
@@ -228,7 +229,7 @@
 
 @media (max-width: 768px) {
   .container {
-    padding: var(--space-4) var(--space-4) var(--space-6);
+    padding: var(--space-4) var(--mobile-gutter) var(--space-6);
     gap: var(--space-4);
     padding-bottom: calc(var(--bottom-bar-height) + var(--space-4));
   }
@@ -240,6 +241,15 @@
   /* FAB handles chat on mobile — hide the Ask button */
   .askBtn {
     display: none;
+  }
+
+  .statPill {
+    padding: var(--space-3) var(--space-4);
+    min-width: 72px;
+  }
+
+  .statPillNum {
+    font-size: 20px;
   }
 }
 

--- a/web/src/components/OverviewPanel.module.css
+++ b/web/src/components/OverviewPanel.module.css
@@ -1,6 +1,7 @@
 .page {
   flex: 1;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
   padding: var(--space-7);
   background:
     radial-gradient(circle at top right, rgba(217, 168, 74, 0.05), transparent 24%),


### PR DESCRIPTION
Created by apiari orchestrator