### PR TITLE
fix(dashboard): prevent horizontal scroll and reduce stat pill size on mobile

### DIFF
--- a/web/src/components/Dashboard/Dashboard.module.css
+++ b/web/src/components/Dashboard/Dashboard.module.css
@@ -5,6 +5,7 @@
   flex-direction: column;
   height: 100%;
   overflow-y: auto;
+  overflow-x: hidden;
   padding: var(--space-7) var(--space-7) var(--space-8);
   background: var(--bg);
   gap: var(--space-6);
@@ -228,13 +229,26 @@
 
 @media (max-width: 768px) {
   .container {
-    padding: var(--space-4) var(--space-4) var(--space-6);
-    gap: var(--space-4);
+    padding: var(--space-3) var(--space-3) var(--space-6);
+    gap: var(--space-3);
     padding-bottom: calc(var(--bottom-bar-height) + var(--space-4));
   }
 
   .widgetGrid {
     grid-template-columns: 1fr;
+  }
+
+  .statPills {
+    gap: var(--space-2);
+  }
+
+  .statPill {
+    padding: var(--space-2) var(--space-3);
+    min-width: 72px;
+  }
+
+  .statPillNum {
+    font-size: 20px;
   }
 
   /* FAB handles chat on mobile — hide the Ask button */


### PR DESCRIPTION
## Summary

- Add `overflow-x: hidden` to the dashboard container to prevent horizontal scrolling on narrow screens
- Reduce mobile padding and gap on the main content area (`space-4` → `space-3`)
- Add mobile-specific overrides for `.statPills`, `.statPill`, and `.statPillNum` to shrink the stat pills so they fit within the phone viewport without overflowing

## Test plan

- [ ] Open the dashboard on a phone-sized viewport (≤768px) — no horizontal scroll bar
- [ ] Stat pills display at a reasonable size and fit within the screen width
- [ ] Desktop layout is unaffected