### PR TITLE
fix(worker-detail): move tool group pill below timestamp

### DIFF
--- a/web/src/components/WorkerDetailV2/WorkerDetailV2.module.css
+++ b/web/src/components/WorkerDetailV2/WorkerDetailV2.module.css
@@ -528,9 +528,8 @@
 /* tool_group */
 .toolGroup {
   display: flex;
-  flex-direction: row;
-  gap: var(--space-3);
-  align-items: flex-start;
+  flex-direction: column;
+  gap: 4px;
   cursor: pointer;
   user-select: none;
   padding: 2px 0;
@@ -541,7 +540,6 @@
   flex-direction: row;
   align-items: flex-start;
   gap: 6px;
-  flex: 1;
   min-width: 0;
 }
 


### PR DESCRIPTION
## Summary

- The expandable tool-call pill in the worker chat timeline was rendered inline beside the timestamp (using `flex-direction: row`), while all other event types (assistant text, user messages, system events) place the timestamp above the content (`flex-direction: column`)
- Changed `.toolGroup` CSS from `flex-direction: row` to `flex-direction: column` with `gap: 4px` to match the `eventRow` layout, so the time appears above the pill consistently
- Removed the now-unused `flex: 1` from `.toolGroupContent`

## Test plan

- [ ] Open a worker detail view with tool calls in the timeline
- [ ] Verify the timestamp appears above the expandable pill, not beside it
- [ ] Verify expanding the pill still shows tool details correctly
- [ ] All 273 frontend tests pass